### PR TITLE
Harden manifest validation and duplicate checks

### DIFF
--- a/ash-archive/tests/test_duplicate_mods.py
+++ b/ash-archive/tests/test_duplicate_mods.py
@@ -1,4 +1,8 @@
-from tools.check_duplicate_mods import find_duplicates
+from tools.check_duplicate_mods import (
+    DuplicateReport,
+    find_cross_edition_name_mismatches,
+    find_duplicates,
+)
 
 
 def test_find_duplicate_ids_and_names() -> None:
@@ -7,6 +11,25 @@ def test_find_duplicate_ids_and_names() -> None:
         {"id": "a", "name": "Same"},
         {"id": "b", "name": "Same"},
     ]
-    dup_ids, dup_names = find_duplicates(mods)
-    assert dup_ids == ["a"]
-    assert dup_names == ["Same"]
+    duplicates = find_duplicates(mods)
+    assert duplicates == DuplicateReport(
+        duplicate_ids=["a"],
+        duplicate_names_with_different_ids=["Same"],
+    )
+
+
+def test_cross_edition_duplicate_names_with_different_ids_warn() -> None:
+    warnings = find_cross_edition_name_mismatches(
+        {
+            "openmw": [{"id": "patch-for-purists-openmw", "name": "Patch for Purists"}],
+            "mwse": [{"id": "patch-for-purists-mwse", "name": "Patch for Purists"}],
+        }
+    )
+
+    assert warnings == [
+        (
+            "all editions",
+            "Patch for Purists",
+            "mwse: patch-for-purists-mwse; openmw: patch-for-purists-openmw",
+        )
+    ]

--- a/ash-archive/tests/test_validation.py
+++ b/ash-archive/tests/test_validation.py
@@ -1,6 +1,37 @@
 from pathlib import Path
 
+import pytest
+import yaml
+
 from tools.lib.validation import validate_manifest
+
+
+FIXTURE_REQUIRED_FIELDS = {
+    "id": "sample-mod",
+    "name": "Sample Mod",
+    "category": "Bug Fixes and Stability",
+    "edition": "openmw",
+    "cross_edition_status": "equivalent-needed",
+    "status": "planned",
+    "engine": ["openmw"],
+    "source": "tbd",
+    "url": "",
+    "archive_name": "",
+    "version": "",
+    "plugin_files": [],
+    "requires": [],
+    "conflicts": [],
+    "load_after": [],
+    "load_before": [],
+    "patch_notes": "needs verification",
+    "testing_notes": "needs verification",
+    "decision_reason": "fixture",
+    "priority": 1,
+}
+
+
+def _write_manifest(path: Path, mods: list[dict]) -> None:
+    path.write_text(yaml.safe_dump({"mods": mods}, sort_keys=False), encoding="utf-8")
 
 
 def test_valid_fixture_passes() -> None:
@@ -14,5 +45,83 @@ def test_invalid_fixture_fails() -> None:
     joined = "\n".join(errors)
     assert "invalid id" in joined
     assert "invalid cross_edition_status" in joined
-    assert "priority" in joined
+    assert "field 'priority' must be integer" in joined
     assert "invalid category" in joined
+
+
+def test_missing_required_field_fails(tmp_path: Path) -> None:
+    mod = dict(FIXTURE_REQUIRED_FIELDS)
+    mod.pop("url")
+    fixture = tmp_path / "mods.yaml"
+    _write_manifest(fixture, [mod])
+
+    errors = validate_manifest(fixture, "openmw")
+
+    assert any("missing field 'url'" in error for error in errors)
+
+
+def test_invalid_enum_fails(tmp_path: Path) -> None:
+    mod = dict(FIXTURE_REQUIRED_FIELDS)
+    mod["status"] = "not-valid"
+    fixture = tmp_path / "mods.yaml"
+    _write_manifest(fixture, [mod])
+
+    errors = validate_manifest(fixture, "openmw")
+
+    assert any("invalid status" in error for error in errors)
+
+
+def test_invalid_category_fails(tmp_path: Path) -> None:
+    mod = dict(FIXTURE_REQUIRED_FIELDS)
+    mod["category"] = "Bugfixes"
+    fixture = tmp_path / "mods.yaml"
+    _write_manifest(fixture, [mod])
+
+    errors = validate_manifest(fixture, "openmw")
+
+    assert any("invalid category" in error for error in errors)
+
+
+@pytest.mark.parametrize("invalid_id", ["Patch For Purists", "patch_for_purists", "Patch-for-Purists", "patch for purists"])
+def test_invalid_kebab_case_id_fails(tmp_path: Path, invalid_id: str) -> None:
+    mod = dict(FIXTURE_REQUIRED_FIELDS)
+    mod["id"] = invalid_id
+    fixture = tmp_path / "mods.yaml"
+    _write_manifest(fixture, [mod])
+
+    errors = validate_manifest(fixture, "openmw")
+
+    assert any("expected lowercase kebab-case" in error for error in errors)
+
+
+def test_edition_mismatch_fails(tmp_path: Path) -> None:
+    mod = dict(FIXTURE_REQUIRED_FIELDS)
+    mod["edition"] = "mwse"
+    fixture = tmp_path / "mods.yaml"
+    _write_manifest(fixture, [mod])
+
+    errors = validate_manifest(fixture, "openmw")
+
+    assert any("edition mismatch" in error for error in errors)
+
+
+def test_openmw_manifest_rejects_mwse_engine_value(tmp_path: Path) -> None:
+    mod = dict(FIXTURE_REQUIRED_FIELDS)
+    mod["engine"] = ["mwse"]
+    fixture = tmp_path / "mods.yaml"
+    _write_manifest(fixture, [mod])
+
+    errors = validate_manifest(fixture, "openmw")
+
+    assert any("invalid engine values" in error for error in errors)
+
+
+def test_engine_unknown_cannot_be_combined(tmp_path: Path) -> None:
+    mod = dict(FIXTURE_REQUIRED_FIELDS)
+    mod["engine"] = ["unknown", "openmw"]
+    fixture = tmp_path / "mods.yaml"
+    _write_manifest(fixture, [mod])
+
+    errors = validate_manifest(fixture, "openmw")
+
+    assert any("cannot combine 'unknown'" in error for error in errors)

--- a/ash-archive/tests/test_validation.py
+++ b/ash-archive/tests/test_validation.py
@@ -82,7 +82,10 @@ def test_invalid_category_fails(tmp_path: Path) -> None:
     assert any("invalid category" in error for error in errors)
 
 
-@pytest.mark.parametrize("invalid_id", ["Patch For Purists", "patch_for_purists", "Patch-for-Purists", "patch for purists"])
+@pytest.mark.parametrize(
+    "invalid_id",
+    ["Patch For Purists", "patch_for_purists", "Patch-for-Purists", "patch for purists"],
+)
 def test_invalid_kebab_case_id_fails(tmp_path: Path, invalid_id: str) -> None:
     mod = dict(FIXTURE_REQUIRED_FIELDS)
     mod["id"] = invalid_id

--- a/ash-archive/tools/check_duplicate_mods.py
+++ b/ash-archive/tools/check_duplicate_mods.py
@@ -2,36 +2,95 @@
 from __future__ import annotations
 
 from collections import defaultdict
+from dataclasses import dataclass
+from pathlib import Path
 
 from lib.manifest import load_mods
 from lib.paths import EDITIONS, manifest_path
 
 
-def find_duplicates(mods: list[dict]) -> tuple[list[str], list[str]]:
+@dataclass
+class DuplicateReport:
+    duplicate_ids: list[str]
+    duplicate_names_with_different_ids: list[str]
+
+
+def find_duplicates(mods: list[dict]) -> DuplicateReport:
     id_counts = defaultdict(int)
     name_to_ids = defaultdict(set)
     for mod in mods:
-        id_counts[mod.get("id", "")] += 1
-        name_to_ids[mod.get("name", "")].add(mod.get("id", ""))
-    dup_ids = [mod_id for mod_id, c in id_counts.items() if mod_id and c > 1]
-    dup_names = [name for name, ids in name_to_ids.items() if name and len(ids) > 1]
-    return dup_ids, dup_names
+        mod_id = mod.get("id")
+        mod_name = mod.get("name")
+        if isinstance(mod_id, str) and mod_id:
+            id_counts[mod_id] += 1
+        if isinstance(mod_name, str) and mod_name and isinstance(mod_id, str) and mod_id:
+            name_to_ids[mod_name].add(mod_id)
+
+    dup_ids = sorted(mod_id for mod_id, count in id_counts.items() if count > 1)
+    dup_names = sorted(name for name, ids in name_to_ids.items() if len(ids) > 1)
+    return DuplicateReport(duplicate_ids=dup_ids, duplicate_names_with_different_ids=dup_names)
+
+
+def find_cross_edition_name_mismatches(mods_by_edition: dict[str, list[dict]]) -> list[tuple[str, str, str]]:
+    name_to_edition_ids: dict[str, dict[str, set[str]]] = defaultdict(lambda: defaultdict(set))
+    for edition, mods in mods_by_edition.items():
+        for mod in mods:
+            mod_id = mod.get("id")
+            mod_name = mod.get("name")
+            if isinstance(mod_name, str) and mod_name and isinstance(mod_id, str) and mod_id:
+                name_to_edition_ids[mod_name][edition].add(mod_id)
+
+    warnings: list[tuple[str, str, str]] = []
+    for name, edition_ids in sorted(name_to_edition_ids.items()):
+        if len(edition_ids) < 2:
+            continue
+        merged_ids = set().union(*edition_ids.values())
+        if len(merged_ids) <= 1:
+            continue
+        detail = "; ".join(
+            f"{edition}: {', '.join(sorted(ids))}" for edition, ids in sorted(edition_ids.items())
+        )
+        warnings.append(("all editions", name, detail))
+    return warnings
+
+
+def _load_mods_for_path(path: Path) -> list[dict]:
+    try:
+        return load_mods(path)
+    except ValueError as exc:
+        print(f"[ERROR] {exc}")
+        return []
 
 
 def main() -> int:
-    warnings = False
+    has_errors = False
+    mods_by_edition: dict[str, list[dict]] = {}
+
     for edition in EDITIONS:
         path = manifest_path(edition)
-        mods = load_mods(path)
-        dup_ids, dup_names = find_duplicates(mods)
-        if dup_ids or dup_names:
-            warnings = True
-        if dup_ids:
-            print(f"[{edition}] duplicate ids: {', '.join(sorted(dup_ids))}")
-        if dup_names:
-            print(f"[{edition}] duplicate names across ids: {', '.join(sorted(dup_names))}")
-    if not warnings:
-        print("No likely accidental duplicates found.")
+        mods = _load_mods_for_path(path)
+        mods_by_edition[edition] = mods
+        report = find_duplicates(mods)
+
+        for mod_id in report.duplicate_ids:
+            has_errors = True
+            print(f"[ERROR] {path} :: {mod_id} :: duplicate id in manifest")
+        for name in report.duplicate_names_with_different_ids:
+            print(
+                f"[WARN] {path} :: {name} :: duplicate name used by different ids in this manifest"
+            )
+
+    cross_warnings = find_cross_edition_name_mismatches(mods_by_edition)
+    for scope, name, detail in cross_warnings:
+        print(f"[WARN] {scope} :: {name} :: duplicate name across editions with different ids ({detail})")
+
+    if has_errors:
+        return 1
+
+    if not cross_warnings and all(not find_duplicates(mods).duplicate_names_with_different_ids for mods in mods_by_edition.values()):
+        print("[OK] No duplicate IDs or likely accidental duplicate names found.")
+    else:
+        print("[OK] Duplicate scan completed with warnings only.")
     return 0
 
 

--- a/ash-archive/tools/check_duplicate_mods.py
+++ b/ash-archive/tools/check_duplicate_mods.py
@@ -31,7 +31,9 @@ def find_duplicates(mods: list[dict]) -> DuplicateReport:
     return DuplicateReport(duplicate_ids=dup_ids, duplicate_names_with_different_ids=dup_names)
 
 
-def find_cross_edition_name_mismatches(mods_by_edition: dict[str, list[dict]]) -> list[tuple[str, str, str]]:
+def find_cross_edition_name_mismatches(
+    mods_by_edition: dict[str, list[dict]],
+) -> list[tuple[str, str, str]]:
     name_to_edition_ids: dict[str, dict[str, set[str]]] = defaultdict(lambda: defaultdict(set))
     for edition, mods in mods_by_edition.items():
         for mod in mods:
@@ -82,12 +84,17 @@ def main() -> int:
 
     cross_warnings = find_cross_edition_name_mismatches(mods_by_edition)
     for scope, name, detail in cross_warnings:
-        print(f"[WARN] {scope} :: {name} :: duplicate name across editions with different ids ({detail})")
+        print(
+            f"[WARN] {scope} :: {name} :: duplicate name across editions with different ids ({detail})"
+        )
 
     if has_errors:
         return 1
 
-    if not cross_warnings and all(not find_duplicates(mods).duplicate_names_with_different_ids for mods in mods_by_edition.values()):
+    if not cross_warnings and all(
+        not find_duplicates(mods).duplicate_names_with_different_ids
+        for mods in mods_by_edition.values()
+    ):
         print("[OK] No duplicate IDs or likely accidental duplicate names found.")
     else:
         print("[OK] Duplicate scan completed with warnings only.")

--- a/ash-archive/tools/lib/manifest.py
+++ b/ash-archive/tools/lib/manifest.py
@@ -6,8 +6,14 @@ import yaml
 
 
 def load_yaml(path: Path) -> dict:
-    with path.open("r", encoding="utf-8") as handle:
-        data = yaml.safe_load(handle) or {}
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            data = yaml.safe_load(handle) or {}
+    except FileNotFoundError as exc:
+        raise ValueError(f"Missing YAML file: {path}") from exc
+    except yaml.YAMLError as exc:
+        raise ValueError(f"Invalid YAML in {path}: {exc}") from exc
+
     if not isinstance(data, dict):
         raise ValueError(f"Top-level YAML must be a mapping: {path}")
     return data

--- a/ash-archive/tools/lib/markdown.py
+++ b/ash-archive/tools/lib/markdown.py
@@ -1,4 +1,10 @@
+from __future__ import annotations
+
 from collections import defaultdict
+
+
+def _sanitize_inline(value: str) -> str:
+    return " ".join(value.replace("`", "'").splitlines()).strip()
 
 
 def render_mod_sections(mods: list[dict]) -> str:
@@ -7,13 +13,15 @@ def render_mod_sections(mods: list[dict]) -> str:
         grouped[mod["category"]].append(mod)
     lines: list[str] = []
     for category in sorted(grouped):
-        lines.append(f"## {category}")
+        lines.append(f"## {_sanitize_inline(category)}")
         for mod in sorted(grouped[category], key=lambda m: m.get("priority", 9999)):
             engines = ", ".join(mod.get("engine", []))
             lines.append(
-                f"- **{mod['name']}** (`{mod['id']}`) — status: `{mod['status']}`, "
-                f"engine: `{engines}`, cross-edition: `{mod['cross_edition_status']}`. "
-                f"Reason: {mod['decision_reason']}"
+                f"- **{_sanitize_inline(mod['name'])}** "
+                f"(`{_sanitize_inline(mod['id'])}`) — status: `{_sanitize_inline(mod['status'])}`, "
+                f"engine: `{_sanitize_inline(engines)}`, "
+                f"cross-edition: `{_sanitize_inline(mod['cross_edition_status'])}`. "
+                f"Reason: {_sanitize_inline(mod['decision_reason'])}"
             )
         lines.append("")
     return "\n".join(lines).rstrip() + "\n"

--- a/ash-archive/tools/lib/validation.py
+++ b/ash-archive/tools/lib/validation.py
@@ -59,7 +59,7 @@ LIST_FIELDS = ["plugin_files", "requires", "conflicts", "load_after", "load_befo
 
 
 def _format_error(path: Path, mod_ref: str, detail: str) -> str:
-    return f'[ERROR] {path} :: {mod_ref} :: {detail}'
+    return f"[ERROR] {path} :: {mod_ref} :: {detail}"
 
 
 @lru_cache(maxsize=1)
@@ -84,9 +84,7 @@ def _mod_ref(mod: dict) -> str:
     return "<missing-id>"
 
 
-def _validate_enum_fields(
-    mod: dict, path: Path, mod_ref: str, expected_edition: str
-) -> list[str]:
+def _validate_enum_fields(mod: dict, path: Path, mod_ref: str, expected_edition: str) -> list[str]:
     errors: list[str] = []
     mod_id = mod.get("id")
     if not isinstance(mod_id, str) or not ID_RE.fullmatch(mod_id):
@@ -94,8 +92,7 @@ def _validate_enum_fields(
             _format_error(
                 path,
                 mod_ref,
-                "invalid id "
-                f"{mod_id!r}; expected lowercase kebab-case like 'patch-for-purists'",
+                f"invalid id {mod_id!r}; expected lowercase kebab-case like 'patch-for-purists'",
             )
         )
     if mod["edition"] != expected_edition:
@@ -122,7 +119,7 @@ def _validate_enum_fields(
             _format_error(
                 path,
                 mod_ref,
-                f'invalid category {mod["category"]!r}; expected one of shared/categories.yaml',
+                f"invalid category {mod['category']!r}; expected one of shared/categories.yaml",
             )
         )
     return errors

--- a/ash-archive/tools/lib/validation.py
+++ b/ash-archive/tools/lib/validation.py
@@ -18,89 +18,196 @@ CROSS = {
     "rejected-in-mwse",
 }
 STATUS = {"planned", "testing", "accepted", "rejected", "needs-patch", "deprecated"}
-ENGINE = {"openmw", "mwse", "mcp", "mge-xe", "vanilla", "both", "unknown"}
+ENGINE_BY_EDITION = {
+    "openmw": {"openmw", "vanilla", "both", "unknown"},
+    "mwse": {"mwse", "mcp", "mge-xe", "vanilla", "both", "unknown"},
+}
 REQ_FIELDS = [
-    "id", "name", "category", "edition", "cross_edition_status", "status", "engine",
-    "source", "url", "archive_name", "version", "plugin_files", "requires", "conflicts",
-    "load_after", "load_before", "patch_notes", "testing_notes", "decision_reason", "priority",
+    "id",
+    "name",
+    "category",
+    "edition",
+    "cross_edition_status",
+    "status",
+    "engine",
+    "source",
+    "url",
+    "archive_name",
+    "version",
+    "plugin_files",
+    "requires",
+    "conflicts",
+    "load_after",
+    "load_before",
+    "patch_notes",
+    "testing_notes",
+    "decision_reason",
+    "priority",
 ]
 STR_FIELDS = [
-    "name", "category", "source", "url", "archive_name", "version",
-    "patch_notes", "testing_notes", "decision_reason",
+    "name",
+    "category",
+    "source",
+    "url",
+    "archive_name",
+    "version",
+    "patch_notes",
+    "testing_notes",
+    "decision_reason",
 ]
 LIST_FIELDS = ["plugin_files", "requires", "conflicts", "load_after", "load_before"]
+
+
+def _format_error(path: Path, mod_ref: str, detail: str) -> str:
+    return f'[ERROR] {path} :: {mod_ref} :: {detail}'
 
 
 @lru_cache(maxsize=1)
 def _allowed_categories() -> frozenset[str]:
     data = load_yaml(categories_path())
     cats = data.get("categories", [])
+    if not isinstance(cats, list):
+        raise ValueError(f"Top-level key 'categories' must be a list: {categories_path()}")
+    bad = [c for c in cats if not isinstance(c, str)]
+    if bad:
+        raise ValueError(f"All categories must be strings in: {categories_path()}")
     return frozenset(cats)
 
 
+def _mod_ref(mod: dict) -> str:
+    mod_id = mod.get("id")
+    mod_name = mod.get("name")
+    if isinstance(mod_id, str) and mod_id:
+        return mod_id
+    if isinstance(mod_name, str) and mod_name:
+        return mod_name
+    return "<missing-id>"
+
+
 def _validate_enum_fields(
-    mod: dict, path: Path, mod_id: str, expected_edition: str
+    mod: dict, path: Path, mod_ref: str, expected_edition: str
 ) -> list[str]:
     errors: list[str] = []
-    if not isinstance(mod["id"], str) or not ID_RE.match(mod["id"]):
-        errors.append(f"{path}: mod={mod_id} invalid id; expected lowercase kebab-case")
+    mod_id = mod.get("id")
+    if not isinstance(mod_id, str) or not ID_RE.fullmatch(mod_id):
+        errors.append(
+            _format_error(
+                path,
+                mod_ref,
+                "invalid id "
+                f"{mod_id!r}; expected lowercase kebab-case like 'patch-for-purists'",
+            )
+        )
     if mod["edition"] != expected_edition:
         errors.append(
-            f"{path}: mod={mod_id} edition '{mod['edition']}' must be '{expected_edition}'"
+            _format_error(
+                path,
+                mod_ref,
+                f"edition mismatch: found {mod['edition']!r}, expected {expected_edition!r}",
+            )
         )
     if mod["cross_edition_status"] not in CROSS:
         errors.append(
-            f"{path}: mod={mod_id} invalid cross_edition_status '{mod['cross_edition_status']}'"
+            _format_error(
+                path,
+                mod_ref,
+                f"invalid cross_edition_status {mod['cross_edition_status']!r}",
+            )
         )
     if mod["status"] not in STATUS:
-        errors.append(f"{path}: mod={mod_id} invalid status '{mod['status']}'")
+        errors.append(_format_error(path, mod_ref, f"invalid status {mod['status']!r}"))
     allowed = _allowed_categories()
-    if allowed and mod["category"] not in allowed:
+    if mod["category"] not in allowed:
         errors.append(
-            f"{path}: mod={mod_id} invalid category '{mod['category']}'; "
-            f"must be one of the categories in shared/categories.yaml"
+            _format_error(
+                path,
+                mod_ref,
+                f'invalid category {mod["category"]!r}; expected one of shared/categories.yaml',
+            )
         )
     return errors
 
 
-def _validate_field_types(mod: dict, path: Path, mod_id: str) -> list[str]:
+def _validate_engine_field(mod: dict, path: Path, mod_ref: str, expected_edition: str) -> list[str]:
     errors: list[str] = []
-    if not isinstance(mod["engine"], list) or not mod["engine"]:
-        errors.append(f"{path}: mod={mod_id} engine must be a non-empty list")
-    elif any(e not in ENGINE for e in mod["engine"]):
-        errors.append(f"{path}: mod={mod_id} invalid engine values {mod['engine']}")
-    for f in LIST_FIELDS:
-        if not isinstance(mod[f], list) or any(not isinstance(x, str) for x in mod[f]):
-            errors.append(f"{path}: mod={mod_id} field '{f}' must be list[str]")
-    for f in STR_FIELDS:
-        if not isinstance(mod[f], str):
-            errors.append(f"{path}: mod={mod_id} field '{f}' must be a string")
+    engine = mod["engine"]
+    if not isinstance(engine, list):
+        return [_format_error(path, mod_ref, "field 'engine' must be list[str]")]
+    if not engine:
+        return [_format_error(path, mod_ref, "engine must be a non-empty list")]
+    if any(not isinstance(e, str) for e in engine):
+        return [_format_error(path, mod_ref, "field 'engine' must be list[str]")]
+
+    allowed = ENGINE_BY_EDITION[expected_edition]
+    invalid = [e for e in engine if e not in allowed]
+    if invalid:
+        errors.append(
+            _format_error(
+                path,
+                mod_ref,
+                f"invalid engine values {invalid!r} for edition {expected_edition!r}",
+            )
+        )
+
+    unique_values = set(engine)
+    if "unknown" in unique_values and len(unique_values) > 1:
+        errors.append(
+            _format_error(
+                path,
+                mod_ref,
+                "engine cannot combine 'unknown' with other values",
+            )
+        )
+    if "both" in unique_values and len(unique_values) > 1:
+        errors.append(
+            _format_error(
+                path,
+                mod_ref,
+                "engine cannot combine 'both' with other values",
+            )
+        )
+    return errors
+
+
+def _validate_field_types(mod: dict, path: Path, mod_ref: str, expected_edition: str) -> list[str]:
+    errors: list[str] = []
+    errors.extend(_validate_engine_field(mod, path, mod_ref, expected_edition))
+    for field_name in LIST_FIELDS:
+        value = mod[field_name]
+        if not isinstance(value, list) or any(not isinstance(item, str) for item in value):
+            errors.append(_format_error(path, mod_ref, f"field '{field_name}' must be list[str]"))
+    for field_name in STR_FIELDS:
+        if not isinstance(mod[field_name], str):
+            errors.append(_format_error(path, mod_ref, f"field '{field_name}' must be a string"))
     if not isinstance(mod["priority"], int):
-        errors.append(f"{path}: mod={mod_id} field 'priority' must be integer")
+        errors.append(_format_error(path, mod_ref, "field 'priority' must be integer"))
     return errors
 
 
 def validate_mod(mod: dict, path: Path, expected_edition: str) -> list[str]:
     errors = []
-    mod_id = mod.get("id", "<missing-id>")
-    for f in REQ_FIELDS:
-        if f not in mod:
-            errors.append(f"{path}: mod={mod_id} missing field '{f}'")
+    mod_ref = _mod_ref(mod)
+    for field_name in REQ_FIELDS:
+        if field_name not in mod:
+            errors.append(_format_error(path, mod_ref, f"missing field '{field_name}'"))
     if errors:
         return errors
-    errors.extend(_validate_enum_fields(mod, path, mod_id, expected_edition))
-    errors.extend(_validate_field_types(mod, path, mod_id))
+    errors.extend(_validate_enum_fields(mod, path, mod_ref, expected_edition))
+    errors.extend(_validate_field_types(mod, path, mod_ref, expected_edition))
     return errors
 
 
 def validate_manifest(path: Path, edition: str) -> list[str]:
-    mods = load_mods(path)
+    try:
+        mods = load_mods(path)
+    except ValueError as exc:
+        return [f"[ERROR] {exc}"]
     if not mods:
-        return [f"{path}: no mods defined"]
+        return [f"[ERROR] {path} :: <manifest> :: no mods defined"]
     errors: list[str] = []
     for mod in mods:
         if not isinstance(mod, dict):
-            errors.append(f"{path}: non-object entry in mods list")
+            errors.append(f"[ERROR] {path} :: <manifest> :: non-object entry in mods list")
             continue
         errors.extend(validate_mod(mod, path, edition))
     return errors

--- a/ash-archive/tools/validate_manifests.py
+++ b/ash-archive/tools/validate_manifests.py
@@ -21,12 +21,13 @@ def main() -> int:
     for edition in editions:
         path = manifest_path(edition)
         errors.extend(validate_manifest(path, edition))
+
     if errors:
-        print("Manifest validation failed:")
         for err in errors:
-            print(f"- {err}")
+            print(err)
         return 1
-    print(f"Manifest validation passed for: {', '.join(editions)}")
+
+    print(f"[OK] Manifest validation passed for: {', '.join(editions)}")
     return 0
 
 


### PR DESCRIPTION
### Motivation
- Improve manifest validation robustness and produce actionable, human-readable errors for maintainers. 
- Enforce schema rules (categories, kebab-case ids, edition, engine values, required fields, types) and prevent accidental duplicates across and within editions. 
- Make generated markdown safe against inline control characters and avoid stack traces for normal validation failures.

### Description
- Tightened validation in `tools/lib/validation.py`: added edition-aware engine rules, strict kebab-case `id` checks, exact category validation against `shared/categories.yaml`, clearer `[ERROR]` messages, `missing field` checks, and stronger type checks (`priority` integer, list/str shape), plus handling for malformed/missing YAML. 
- Improved YAML loading errors in `tools/lib/manifest.py` so invalid or missing files return actionable errors. 
- Updated `tools/validate_manifests.py` to print concise error lines and return nonzero on failure and `[OK]` on success. 
- Reworked duplicate scanning in `tools/check_duplicate_mods.py`: introduced `DuplicateReport` dataclass, detect duplicate ids as errors, duplicate names as warnings, and added `find_cross_edition_name_mismatches` to warn on same name with different ids across editions. 
- Sanitized inline values in generated markdown via `tools/lib/markdown.py` to avoid unsafe characters/backticks in `generate_modlist_markdown.py`. 
- Added/updated tests in `tests/test_validation.py` and `tests/test_duplicate_mods.py` to cover valid/invalid fixtures, missing required fields, enum/category/id/edition/engine failures, and duplicate detection behavior.

### Testing
- Ran `python tools/validate_manifests.py` — passed for both `openmw` and `mwse` (success). 
- Ran `python tools/check_duplicate_mods.py` — passed with no duplicate-ID errors (success). 
- Ran `python tools/compare_editions.py` — executed successfully and produced expected summary (success). 
- Ran `python tools/generate_modlist_markdown.py` — updated MODLIST files successfully (success). 
- Ran `pytest` in `ash-archive/` — all tests passed (`16 passed`). 
- Note: an editable install attempt `python -m pip install -e 'ash-archive[dev]'` failed due to setuptools package discovery layout and is unrelated to the validation test suite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed209f57cc83339986dbc86ce86618)