### PR TITLE
Improve sourced-mod workflow and candidate tracking

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,6 +94,12 @@ When updating sourcing records:
 3. Do not invent URLs, archive names, or version identifiers.
 4. Do not mark mods accepted without review/testing notes.
 
+
+## Sourced-mod candidate workflow
+
+Use `ash-archive/shared/sourced-mod-workflow.md` when triaging or promoting sourced candidates.
+Treat `shared/sourced-mods.yaml` as candidate intake metadata, not an accepted-mod manifest.
+
 ## Documentation expectations
 
 1. Keep docs aligned with current repo state (planning/scaffold where applicable).

--- a/ash-archive/shared/sourced-mod-workflow.md
+++ b/ash-archive/shared/sourced-mod-workflow.md
@@ -1,0 +1,42 @@
+# Sourced Mod Workflow (Candidate Intake Desk)
+
+`shared/sourced-mods.yaml` is an **intake desk** for candidates, not a list of accepted mods.
+
+## Candidate intake
+
+For each sourced candidate:
+
+1. Record the source candidate with a stable kebab-case `id` and `name`.
+2. Capture `evidence_notes` and `source_url` (or leave URL empty when unknown).
+3. Set `source_confidence` (`verified`, `likely`, or `unverified`).
+4. Set `compatibility_status` conservatively:
+   - keep `unverified` until tested or backed by reliable documentation
+   - use `needs-testing` or `conflicting-reports` when appropriate
+5. Assign one `thematic_bucket` matching project pillars.
+6. Assign `promotion_target` (`openmw`, `mwse`, `both`, `neither`, or `undecided`).
+7. Document `risk_level` and relevant engine-specific uncertainty in `engine_notes`.
+
+## Promotion paths
+
+Allowed status transitions:
+
+- `candidate` → `under-review` → `promoted`
+- `candidate` → `rejected`
+- `candidate` → `superseded`
+
+## Promotion into edition manifests
+
+- `promoted` candidates should only be added to edition manifests after human review.
+- Promotion can differ between OpenMW and MWSE.
+- Preserve edition-specific implementation logic during promotion.
+- Do not force feature parity between editions.
+
+## Rejection and evidence retention
+
+- Keep rejected entries with reasoning in `promotion_notes`/`evidence_notes`.
+- Do not delete rejection evidence lightly; historical context is valuable for future triage.
+
+## Testing and compatibility claims
+
+- Compatibility remains `unverified` until tested or backed by reliable documentation.
+- If compatibility is marked as tested-compatible (`openmw-compatible`, `mwse-compatible`, or `both-compatible`), include notes describing what was tested and how.

--- a/ash-archive/shared/sourced-mods.yaml
+++ b/ash-archive/shared/sourced-mods.yaml
@@ -1,84 +1,166 @@
-sourced_candidates:
-  - id: patch-for-purists
-    name: Patch for Purists
-    candidate_status: candidate
-    thematic_bucket: foundation
-    intended_editions:
-      - openmw
-      - mwse
-    engine_notes: "Core bug-fix baseline candidate for both editions; verify engine-specific edge cases before promotion."
-    source_type: unknown
-    source_url: ""
-    source_confidence: unverified
-    compatibility_status: unverified
-    evidence_notes: "Candidate carried from manual research notes; no linked source record in this file yet."
-    thematic_reason: "Supports stable baseline world-state before atmosphere and horror layering."
-    risk_level: low
-    promotion_target: both
-    promotion_notes: "Hold at candidate until evidence and compatibility notes are recorded."
-    reviewed_by: []
-    last_reviewed: ""
-    related_manifest_ids: []
+buckets:
+  - name: dream-sixth-house
+    candidates:
+      - id: the-dream-is-the-door
+        name: The Dream is the Door
+        source: nexus
+        source_type: nexus
+        source_url: https://www.nexusmods.com/morrowind/mods/47423
+        source_confidence: verified
+        thematic_bucket: dream-sixth-house
+        intended_editions: [openmw, mwse]
+        compatibility_status: needs-testing
+        promotion_target: both
+        risk_level: medium
+        thematic_reason: Cavern of the Incarnate entrance becomes visible only at twilight, aligning prophecy and spatial access.
+        candidate_status: candidate
+        reviewed_by: []
+        last_reviewed: ""
+        related_manifest_ids: []
+        evidence_notes: Nexus page describes the Cavern of the Incarnate entrance becoming visible only at twilight.
+        engine_notes: Nexus page lists both OpenMW and MWSE tags.
+        promotion_notes: Verify quest progression behavior around Cavern of the Incarnate timing in both OpenMW and MWSE, and confirm no blockers for main-quest access.
 
-  - id: the-dream-is-the-door
-    name: The Dream is the Door
-    candidate_status: candidate
-    thematic_bucket: dream-sixth-house
-    intended_editions:
-      - openmw
-      - mwse
-    engine_notes: "Concept-defining candidate; implementation may diverge by edition."
-    source_type: unknown
-    source_url: ""
-    source_confidence: unverified
-    compatibility_status: unverified
-    evidence_notes: "Candidate carried from manual research notes; source and compatibility evidence pending."
-    thematic_reason: "Directly aligns with dream-horror and Sixth House thematic goals."
-    risk_level: medium
-    promotion_target: undecided
-    promotion_notes: "Needs human review for edition-specific viability and implementation approach."
-    reviewed_by: []
-    last_reviewed: ""
-    related_manifest_ids: []
+      - id: lucid-disturbing-dreams
+        name: Lucid Disturbing Dreams
+        source: nexus
+        source_type: nexus
+        source_url: https://www.nexusmods.com/morrowind/mods/55705
+        source_confidence: verified
+        thematic_bucket: dream-sixth-house
+        intended_editions: [openmw, mwse]
+        compatibility_status: needs-testing
+        promotion_target: both
+        risk_level: medium
+        thematic_reason: Converts Dagoth Ur’s four disturbing dream textboxes into voiced playable dream sequences.
+        candidate_status: candidate
+        reviewed_by: []
+        last_reviewed: ""
+        related_manifest_ids: []
+        evidence_notes: Nexus page states the four disturbing dream textboxes are replaced with voiced playable dream sequences.
+        engine_notes: Nexus page includes OpenMW and MWSE tags.
+        promotion_notes: Test each main-quest dream trigger, subtitle/audio behavior, and ensure no quest-state softlocks in either edition.
 
-  - id: better-blight
-    name: Better Blight
-    candidate_status: candidate
-    thematic_bucket: blight-ash-weather
-    intended_editions:
-      - openmw
-      - mwse
-    engine_notes: "Weather/blight behavior may require edition-specific setup or alternatives."
-    source_type: unknown
-    source_url: ""
-    source_confidence: unverified
-    compatibility_status: unverified
-    evidence_notes: "Candidate carried from manual research notes; no documented compatibility evidence yet."
-    thematic_reason: "Strengthens ash/blight atmosphere pillar."
-    risk_level: medium
-    promotion_target: undecided
-    promotion_notes: "Needs evidence capture before under-review transition."
-    reviewed_by: []
-    last_reviewed: ""
-    related_manifest_ids: []
+      - id: beware-the-sixth-house
+        name: Beware the Sixth House
+        source: nexus
+        source_type: nexus
+        source_url: https://www.nexusmods.com/morrowind/mods/46036
+        source_confidence: verified
+        thematic_bucket: dream-sixth-house
+        intended_editions: [openmw, mwse]
+        compatibility_status: needs-testing
+        promotion_target: both
+        risk_level: high
+        thematic_reason: Makes Sixth House enemies significantly more dangerous; strong horror fit, but difficulty/pacing risk is high.
+        candidate_status: candidate
+        reviewed_by: []
+        last_reviewed: ""
+        related_manifest_ids: []
+        evidence_notes: Nexus page presents this as an overhaul that makes Sixth House enemies more dangerous.
+        engine_notes: Nexus page has no explicit hard engine requirement beyond Morrowind.
+        promotion_notes: Run balance passes in early/mid/late Sixth House encounters for both editions and check for pacing spikes or unavoidable difficulty walls.
 
-  - id: creeping-blight
-    name: Creeping Blight
-    candidate_status: candidate
-    thematic_bucket: blight-ash-weather
-    intended_editions:
-      - openmw
-      - mwse
-    engine_notes: "Potential script dependency risk for Sleeper edition; verify OpenMW behavior separately."
-    source_type: unknown
-    source_url: ""
-    source_confidence: unverified
-    compatibility_status: unverified
-    evidence_notes: "Candidate carried from manual research notes; no linked source retained in current record."
-    thematic_reason: "Reinforces progressive environmental dread through blight presentation."
-    risk_level: high
-    promotion_target: undecided
-    promotion_notes: "Do not promote without evidence-backed compatibility review."
-    reviewed_by: []
-    last_reviewed: ""
-    related_manifest_ids: []
+      - id: kogoruhn-extinct-city-of-ash-and-sulfur
+        name: Kogoruhn - Extinct City of Ash and Sulfur
+        source: nexus
+        source_type: nexus
+        source_url: https://www.nexusmods.com/morrowind/mods/51615
+        source_confidence: verified
+        thematic_bucket: dream-sixth-house
+        intended_editions: [openmw, mwse]
+        compatibility_status: needs-testing
+        promotion_target: both
+        risk_level: high
+        thematic_reason: Turns Kogoruhn into a larger Sixth House horror/location centerpiece; likely central but requires compatibility testing.
+        candidate_status: candidate
+        reviewed_by: []
+        last_reviewed: ""
+        related_manifest_ids: []
+        evidence_notes: Nexus page describes a major Kogoruhn location overhaul themed around ash and sulfur.
+        engine_notes: Nexus page does not clearly state OpenMW/MWSE-only requirements.
+        promotion_notes: Validate compatibility with quest routing, pathing, and major dungeon/location edits in both editions before promotion.
+
+  - name: blight-ash-weather
+    candidates:
+      - id: creeping-blight
+        name: Creeping Blight
+        source: nexus
+        source_type: nexus
+        source_url: https://www.nexusmods.com/morrowind/mods/47904
+        source_confidence: verified
+        thematic_bucket: blight-ash-weather
+        intended_editions: [openmw, mwse]
+        compatibility_status: needs-testing
+        promotion_target: both
+        risk_level: medium
+        thematic_reason: Blight weather expands with main quest progress and, in MWSE, elapsed time.
+        candidate_status: candidate
+        reviewed_by: []
+        last_reviewed: ""
+        related_manifest_ids: []
+        evidence_notes: Nexus page describes blight weather expansion linked to main quest progress, with MWSE time-based expansion support.
+        engine_notes: Nexus page indicates support for OpenMW and MWSE behavior paths.
+        promotion_notes: Confirm weather progression logic and regional intensity in both editions, including MWSE elapsed-time behavior where applicable.
+
+      - id: it-beats-openmw
+        name: It Beats OpenMW
+        source: nexus
+        source_type: nexus
+        source_url: https://www.nexusmods.com/morrowind/mods/57396
+        source_confidence: verified
+        thematic_bucket: blight-ash-weather
+        intended_editions: [openmw]
+        compatibility_status: needs-testing
+        promotion_target: openmw
+        risk_level: medium
+        thematic_reason: Adds OpenMW Red Mountain heartbeat ambience.
+        candidate_status: candidate
+        reviewed_by: []
+        last_reviewed: ""
+        related_manifest_ids: []
+        evidence_notes: Nexus page describes Red Mountain heartbeat ambience implementation for OpenMW.
+        engine_notes: Nexus page clearly identifies OpenMW-only target.
+        promotion_notes: Validate ambient trigger zones, volume balance, and interaction with weather/audio mods in OpenMW.
+
+      - id: heartthrum
+        name: Heartthrum
+        source: nexus
+        source_type: nexus
+        source_url: https://www.nexusmods.com/morrowind/mods/47178
+        source_confidence: verified
+        thematic_bucket: blight-ash-weather
+        intended_editions: [mwse]
+        compatibility_status: needs-testing
+        promotion_target: mwse
+        risk_level: medium
+        thematic_reason: MWSE/MGE XE Red Mountain heartbeat ambience.
+        candidate_status: candidate
+        reviewed_by: []
+        last_reviewed: ""
+        related_manifest_ids: []
+        evidence_notes: Nexus page describes Red Mountain heartbeat ambience for MWSE/MGE XE setups.
+        engine_notes: Nexus page indicates MWSE and MGE XE requirements.
+        promotion_notes: Verify heartbeat ambience triggers and performance with MWSE-heavy stacks and regional weather/audio combinations.
+
+  - name: survival-body-horror
+    candidates:
+      - id: ashfall
+        name: Ashfall
+        source: nexus
+        source_type: nexus
+        source_url: https://www.nexusmods.com/morrowind/mods/49057
+        source_confidence: verified
+        thematic_bucket: survival-body-horror
+        intended_editions: [mwse]
+        compatibility_status: needs-testing
+        promotion_target: mwse
+        risk_level: high
+        thematic_reason: MWSE survival/camping/needs system; supports Sleeper Edition’s body/travel pressure if configured carefully.
+        candidate_status: candidate
+        reviewed_by: []
+        last_reviewed: ""
+        related_manifest_ids: []
+        evidence_notes: Nexus page describes survival mechanics including needs and camping systems.
+        engine_notes: Nexus page specifies MWSE dependency.
+        promotion_notes: Stress-test survival loop settings, UI flow, and compatibility with travel/economy mods in MWSE before any promotion.

--- a/ash-archive/shared/sourced-mods.yaml
+++ b/ash-archive/shared/sourced-mods.yaml
@@ -1,13 +1,84 @@
-buckets:
-  - name: archives-and-evidence
-    candidates:
-      - name: Patch for Purists
-        source: "manual-research"
-      - name: The Dream is the Door
-        source: "manual-research"
-  - name: ash-and-weather
-    candidates:
-      - name: Better Blight
-        source: "manual-research"
-      - name: Creeping Blight
-        source: "manual-research"
+sourced_candidates:
+  - id: patch-for-purists
+    name: Patch for Purists
+    candidate_status: candidate
+    thematic_bucket: foundation
+    intended_editions:
+      - openmw
+      - mwse
+    engine_notes: "Core bug-fix baseline candidate for both editions; verify engine-specific edge cases before promotion."
+    source_type: unknown
+    source_url: ""
+    source_confidence: unverified
+    compatibility_status: unverified
+    evidence_notes: "Candidate carried from manual research notes; no linked source record in this file yet."
+    thematic_reason: "Supports stable baseline world-state before atmosphere and horror layering."
+    risk_level: low
+    promotion_target: both
+    promotion_notes: "Hold at candidate until evidence and compatibility notes are recorded."
+    reviewed_by: []
+    last_reviewed: ""
+    related_manifest_ids: []
+
+  - id: the-dream-is-the-door
+    name: The Dream is the Door
+    candidate_status: candidate
+    thematic_bucket: dream-sixth-house
+    intended_editions:
+      - openmw
+      - mwse
+    engine_notes: "Concept-defining candidate; implementation may diverge by edition."
+    source_type: unknown
+    source_url: ""
+    source_confidence: unverified
+    compatibility_status: unverified
+    evidence_notes: "Candidate carried from manual research notes; source and compatibility evidence pending."
+    thematic_reason: "Directly aligns with dream-horror and Sixth House thematic goals."
+    risk_level: medium
+    promotion_target: undecided
+    promotion_notes: "Needs human review for edition-specific viability and implementation approach."
+    reviewed_by: []
+    last_reviewed: ""
+    related_manifest_ids: []
+
+  - id: better-blight
+    name: Better Blight
+    candidate_status: candidate
+    thematic_bucket: blight-ash-weather
+    intended_editions:
+      - openmw
+      - mwse
+    engine_notes: "Weather/blight behavior may require edition-specific setup or alternatives."
+    source_type: unknown
+    source_url: ""
+    source_confidence: unverified
+    compatibility_status: unverified
+    evidence_notes: "Candidate carried from manual research notes; no documented compatibility evidence yet."
+    thematic_reason: "Strengthens ash/blight atmosphere pillar."
+    risk_level: medium
+    promotion_target: undecided
+    promotion_notes: "Needs evidence capture before under-review transition."
+    reviewed_by: []
+    last_reviewed: ""
+    related_manifest_ids: []
+
+  - id: creeping-blight
+    name: Creeping Blight
+    candidate_status: candidate
+    thematic_bucket: blight-ash-weather
+    intended_editions:
+      - openmw
+      - mwse
+    engine_notes: "Potential script dependency risk for Sleeper edition; verify OpenMW behavior separately."
+    source_type: unknown
+    source_url: ""
+    source_confidence: unverified
+    compatibility_status: unverified
+    evidence_notes: "Candidate carried from manual research notes; no linked source retained in current record."
+    thematic_reason: "Reinforces progressive environmental dread through blight presentation."
+    risk_level: high
+    promotion_target: undecided
+    promotion_notes: "Do not promote without evidence-backed compatibility review."
+    reviewed_by: []
+    last_reviewed: ""
+    related_manifest_ids: []

--- a/ash-archive/tests/fixtures/invalid_sourced_mods.yaml
+++ b/ash-archive/tests/fixtures/invalid_sourced_mods.yaml
@@ -1,0 +1,20 @@
+sourced_candidates:
+  - id: Sample Candidate
+    name: Invalid Candidate
+    candidate_status: accepted
+    thematic_bucket: weather
+    intended_editions:
+      - both
+    engine_notes: "Invalid enum fixture"
+    source_type: unknown
+    source_url: ""
+    source_confidence: unverified
+    compatibility_status: unverified
+    evidence_notes: "Intentionally invalid fixture."
+    thematic_reason: "Fixture test"
+    risk_level: unknown
+    promotion_target: undecided
+    promotion_notes: ""
+    reviewed_by: []
+    last_reviewed: ""
+    related_manifest_ids: []

--- a/ash-archive/tests/fixtures/valid_sourced_mods.yaml
+++ b/ash-archive/tests/fixtures/valid_sourced_mods.yaml
@@ -1,0 +1,22 @@
+sourced_candidates:
+  - id: sample-candidate
+    name: Sample Candidate
+    candidate_status: candidate
+    thematic_bucket: foundation
+    intended_editions:
+      - openmw
+    engine_notes: "Candidate-only note"
+    source_type: documentation
+    source_url: "https://example.invalid/docs"
+    source_confidence: likely
+    compatibility_status: unverified
+    evidence_notes: "Documented as candidate only; testing pending."
+    thematic_reason: "Supports foundation stability goals."
+    risk_level: low
+    promotion_target: openmw
+    promotion_notes: "Needs human review before promotion."
+    reviewed_by:
+      - Maintainer A
+    last_reviewed: "2026-04-25"
+    related_manifest_ids:
+      - sample-manifest-id

--- a/ash-archive/tests/test_sourced_mods.py
+++ b/ash-archive/tests/test_sourced_mods.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+from pathlib import Path
+import subprocess
+
+import yaml
+
+from tools.lib.sourced_mods import validate_sourced_mods
+
+
+FIXTURE_REQUIRED_FIELDS = {
+    "id": "sample-candidate",
+    "name": "Sample Candidate",
+    "candidate_status": "candidate",
+    "thematic_bucket": "foundation",
+    "intended_editions": ["openmw"],
+    "engine_notes": "Candidate note",
+    "source_type": "unknown",
+    "source_url": "",
+    "source_confidence": "unverified",
+    "compatibility_status": "unverified",
+    "evidence_notes": "Needs evidence",
+    "thematic_reason": "Fixture",
+    "risk_level": "unknown",
+    "promotion_target": "undecided",
+    "promotion_notes": "",
+    "reviewed_by": [],
+    "last_reviewed": "",
+    "related_manifest_ids": [],
+}
+
+
+def _write_sourced(path: Path, entries: list[dict]) -> None:
+    path.write_text(yaml.safe_dump({"sourced_candidates": entries}, sort_keys=False), encoding="utf-8")
+
+
+def test_valid_sourced_fixture_passes() -> None:
+    _, errors = validate_sourced_mods(Path("tests/fixtures/valid_sourced_mods.yaml"))
+    assert errors == []
+
+
+def test_missing_required_field_fails(tmp_path: Path) -> None:
+    candidate = dict(FIXTURE_REQUIRED_FIELDS)
+    candidate.pop("source_type")
+    fixture = tmp_path / "sourced-mods.yaml"
+    _write_sourced(fixture, [candidate])
+
+    _, errors = validate_sourced_mods(fixture)
+
+    assert any("missing field 'source_type'" in error for error in errors)
+
+
+def test_invalid_candidate_status_fails(tmp_path: Path) -> None:
+    candidate = dict(FIXTURE_REQUIRED_FIELDS)
+    candidate["candidate_status"] = "accepted"
+    fixture = tmp_path / "sourced-mods.yaml"
+    _write_sourced(fixture, [candidate])
+
+    _, errors = validate_sourced_mods(fixture)
+
+    assert any("invalid candidate_status" in error for error in errors)
+
+
+def test_invalid_thematic_bucket_fails(tmp_path: Path) -> None:
+    candidate = dict(FIXTURE_REQUIRED_FIELDS)
+    candidate["thematic_bucket"] = "weather"
+    fixture = tmp_path / "sourced-mods.yaml"
+    _write_sourced(fixture, [candidate])
+
+    _, errors = validate_sourced_mods(fixture)
+
+    assert any("invalid thematic_bucket" in error for error in errors)
+
+
+def test_invalid_intended_editions_fails(tmp_path: Path) -> None:
+    candidate = dict(FIXTURE_REQUIRED_FIELDS)
+    candidate["intended_editions"] = ["both"]
+    fixture = tmp_path / "sourced-mods.yaml"
+    _write_sourced(fixture, [candidate])
+
+    _, errors = validate_sourced_mods(fixture)
+
+    assert any("invalid intended_editions" in error for error in errors)
+
+
+def test_invalid_fixture_fails_for_multiple_reasons() -> None:
+    _, errors = validate_sourced_mods(Path("tests/fixtures/invalid_sourced_mods.yaml"))
+    assert errors
+    joined = "\n".join(errors)
+    assert "invalid id" in joined
+    assert "invalid candidate_status" in joined
+    assert "invalid thematic_bucket" in joined
+    assert "invalid intended_editions" in joined
+
+
+def test_invalid_kebab_case_id_fails(tmp_path: Path) -> None:
+    candidate = dict(FIXTURE_REQUIRED_FIELDS)
+    candidate["id"] = "Sample Candidate"
+    fixture = tmp_path / "sourced-mods.yaml"
+    _write_sourced(fixture, [candidate])
+
+    _, errors = validate_sourced_mods(fixture)
+
+    assert any("expected lowercase kebab-case" in error for error in errors)
+
+
+def test_summary_tool_returns_nonzero_for_invalid_fixture() -> None:
+    result = subprocess.run(
+        [
+            "python",
+            "tools/summarize_sourced_mods.py",
+            "--file",
+            "tests/fixtures/invalid_sourced_mods.yaml",
+        ],
+        cwd=Path(__file__).resolve().parents[1],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode != 0
+    assert "[ERROR]" in result.stdout

--- a/ash-archive/tools/lib/sourced_mods.py
+++ b/ash-archive/tools/lib/sourced_mods.py
@@ -1,0 +1,176 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from .manifest import load_yaml
+
+ID_RE = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
+
+REQUIRED_FIELDS = [
+    "id",
+    "name",
+    "candidate_status",
+    "thematic_bucket",
+    "intended_editions",
+    "engine_notes",
+    "source_type",
+    "source_url",
+    "source_confidence",
+    "compatibility_status",
+    "evidence_notes",
+    "thematic_reason",
+    "risk_level",
+    "promotion_target",
+    "promotion_notes",
+    "reviewed_by",
+    "last_reviewed",
+    "related_manifest_ids",
+]
+
+CANDIDATE_STATUS = {"candidate", "under-review", "promoted", "rejected", "superseded"}
+THEMATIC_BUCKETS = {
+    "foundation",
+    "engine-tools",
+    "dream-sixth-house",
+    "blight-ash-weather",
+    "soundscape-silence",
+    "visual-atmosphere",
+    "travel-pilgrimage",
+    "factions-politics",
+    "quests-archives",
+    "survival-body-horror",
+    "ui-perception",
+    "landmass-expansion",
+    "patches-compatibility",
+}
+INTENDED_EDITIONS = {"openmw", "mwse"}
+SOURCE_TYPES = {"nexus", "modding-openmw", "github", "author-site", "documentation", "unknown"}
+SOURCE_CONFIDENCE = {"verified", "likely", "unverified"}
+COMPATIBILITY_STATUS = {
+    "unverified",
+    "openmw-compatible",
+    "mwse-compatible",
+    "both-compatible",
+    "incompatible",
+    "needs-testing",
+    "conflicting-reports",
+}
+RISK_LEVELS = {"low", "medium", "high", "unknown"}
+PROMOTION_TARGETS = {"openmw", "mwse", "both", "neither", "undecided"}
+
+
+def _format_error(path: Path, mod_ref: str, detail: str) -> str:
+    return f"[ERROR] {path} :: {mod_ref} :: {detail}"
+
+
+def _mod_ref(candidate: dict) -> str:
+    mod_id = candidate.get("id")
+    mod_name = candidate.get("name")
+    if isinstance(mod_id, str) and mod_id:
+        return mod_id
+    if isinstance(mod_name, str) and mod_name:
+        return mod_name
+    return "<missing-id>"
+
+
+def _validate_string_field(candidate: dict, field_name: str, path: Path, mod_ref: str) -> list[str]:
+    if not isinstance(candidate[field_name], str):
+        return [_format_error(path, mod_ref, f"field '{field_name}' must be a string")]
+    return []
+
+
+def validate_candidate(candidate: dict, path: Path) -> list[str]:
+    errors: list[str] = []
+    mod_ref = _mod_ref(candidate)
+
+    for field_name in REQUIRED_FIELDS:
+        if field_name not in candidate:
+            errors.append(_format_error(path, mod_ref, f"missing field '{field_name}'"))
+    if errors:
+        return errors
+
+    mod_id = candidate["id"]
+    if not isinstance(mod_id, str) or not ID_RE.fullmatch(mod_id):
+        errors.append(
+            _format_error(path, mod_ref, f"invalid id {mod_id!r}; expected lowercase kebab-case")
+        )
+
+    errors.extend(_validate_string_field(candidate, "name", path, mod_ref))
+    errors.extend(_validate_string_field(candidate, "engine_notes", path, mod_ref))
+    errors.extend(_validate_string_field(candidate, "source_url", path, mod_ref))
+    errors.extend(_validate_string_field(candidate, "evidence_notes", path, mod_ref))
+    errors.extend(_validate_string_field(candidate, "thematic_reason", path, mod_ref))
+    errors.extend(_validate_string_field(candidate, "promotion_notes", path, mod_ref))
+    errors.extend(_validate_string_field(candidate, "last_reviewed", path, mod_ref))
+
+    if candidate["candidate_status"] not in CANDIDATE_STATUS:
+        errors.append(
+            _format_error(path, mod_ref, f"invalid candidate_status {candidate['candidate_status']!r}")
+        )
+    if candidate["thematic_bucket"] not in THEMATIC_BUCKETS:
+        errors.append(
+            _format_error(path, mod_ref, f"invalid thematic_bucket {candidate['thematic_bucket']!r}")
+        )
+    if candidate["source_type"] not in SOURCE_TYPES:
+        errors.append(_format_error(path, mod_ref, f"invalid source_type {candidate['source_type']!r}"))
+    if candidate["source_confidence"] not in SOURCE_CONFIDENCE:
+        errors.append(
+            _format_error(path, mod_ref, f"invalid source_confidence {candidate['source_confidence']!r}")
+        )
+    if candidate["compatibility_status"] not in COMPATIBILITY_STATUS:
+        errors.append(
+            _format_error(
+                path,
+                mod_ref,
+                f"invalid compatibility_status {candidate['compatibility_status']!r}",
+            )
+        )
+    if candidate["risk_level"] not in RISK_LEVELS:
+        errors.append(_format_error(path, mod_ref, f"invalid risk_level {candidate['risk_level']!r}"))
+    if candidate["promotion_target"] not in PROMOTION_TARGETS:
+        errors.append(
+            _format_error(path, mod_ref, f"invalid promotion_target {candidate['promotion_target']!r}")
+        )
+
+    intended_editions = candidate["intended_editions"]
+    if not isinstance(intended_editions, list) or not intended_editions:
+        errors.append(_format_error(path, mod_ref, "field 'intended_editions' must be a non-empty list"))
+    elif any(not isinstance(edition, str) for edition in intended_editions):
+        errors.append(_format_error(path, mod_ref, "field 'intended_editions' must be list[str]"))
+    else:
+        invalid_editions = [edition for edition in intended_editions if edition not in INTENDED_EDITIONS]
+        if invalid_editions:
+            errors.append(
+                _format_error(path, mod_ref, f"invalid intended_editions values {invalid_editions!r}")
+            )
+
+    for field_name in ("reviewed_by", "related_manifest_ids"):
+        value = candidate[field_name]
+        if not isinstance(value, list) or any(not isinstance(item, str) for item in value):
+            errors.append(_format_error(path, mod_ref, f"field '{field_name}' must be list[str]"))
+
+    return errors
+
+
+def load_sourced_candidates(path: Path) -> list[dict]:
+    data = load_yaml(path)
+    candidates = data.get("sourced_candidates")
+    if not isinstance(candidates, list):
+        raise ValueError(f"Top-level key 'sourced_candidates' must be a list: {path}")
+    return candidates
+
+
+def validate_sourced_mods(path: Path) -> tuple[list[dict], list[str]]:
+    try:
+        candidates = load_sourced_candidates(path)
+    except ValueError as exc:
+        return [], [f"[ERROR] {exc}"]
+
+    errors: list[str] = []
+    for candidate in candidates:
+        if not isinstance(candidate, dict):
+            errors.append(f"[ERROR] {path} :: <entry> :: non-object entry in sourced_candidates")
+            continue
+        errors.extend(validate_candidate(candidate, path))
+    return candidates, errors

--- a/ash-archive/tools/summarize_sourced_mods.py
+++ b/ash-archive/tools/summarize_sourced_mods.py
@@ -1,19 +1,66 @@
 #!/usr/bin/env python3
 from __future__ import annotations
 
-from lib.manifest import load_yaml
+import argparse
+from collections import defaultdict
+from pathlib import Path
+
 from lib.paths import ROOT
+from lib.sourced_mods import validate_sourced_mods
+
+
+SUMMARY_FIELDS = [
+    "candidate_status",
+    "intended_editions",
+    "compatibility_status",
+    "risk_level",
+    "source_confidence",
+]
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Summarize sourced-mod candidates by thematic bucket.")
+    parser.add_argument(
+        "--file",
+        type=Path,
+        default=ROOT / "shared" / "sourced-mods.yaml",
+        help="Path to sourced-mods yaml file (default: shared/sourced-mods.yaml)",
+    )
+    return parser.parse_args()
 
 
 def main() -> int:
-    data = load_yaml(ROOT / "shared" / "sourced-mods.yaml")
-    buckets = data.get("buckets", [])
-    for bucket in buckets:
-        print(f"\n[{bucket.get('name', 'unknown')}]")
-        print("name | source")
-        print("---- | ------")
-        for cand in bucket.get("candidates", []):
-            print(f"{cand.get('name', '')} | {cand.get('source', '')}")
+    args = _parse_args()
+    candidates, errors = validate_sourced_mods(args.file)
+
+    if errors:
+        for error in errors:
+            print(error)
+        return 1
+
+    grouped: dict[str, list[dict]] = defaultdict(list)
+    for candidate in candidates:
+        grouped[candidate["thematic_bucket"]].append(candidate)
+
+    print("Sourced mod candidates (intake desk)")
+    print(f"Total: {len(candidates)}")
+    print()
+
+    for bucket in sorted(grouped):
+        print(f"[{bucket}]")
+        print("id | name | candidate_status | intended_editions | compatibility_status | risk_level | source_confidence")
+        print("-- | ---- | ---------------- | ----------------- | -------------------- | ---------- | -----------------")
+        for candidate in sorted(grouped[bucket], key=lambda item: item["id"]):
+            row = [candidate["id"], candidate["name"]]
+            for field in SUMMARY_FIELDS:
+                value = candidate[field]
+                if isinstance(value, list):
+                    row.append(",".join(value))
+                else:
+                    row.append(value)
+            print(" | ".join(row))
+        print()
+
     return 0
 
 


### PR DESCRIPTION
### Motivation
- Treat `shared/sourced-mods.yaml` as an intake desk for sourced candidates rather than an accepted-mod manifest and provide a normalized schema for reliable triage and promotion decisions.
- Add deterministic validation and a concise summary view so candidates are grouped and surfaced with conservative compatibility and evidence metadata before any human promotion into edition manifests.
- Preserve existing candidates and avoid inventing new metadata, changing edition manifests, or claiming tested compatibility without evidence.

### Description
- Redesign `ash-archive/shared/sourced-mods.yaml` to a `sourced_candidates` list with the required normalized fields (ids in kebab-case, `candidate_status`, `thematic_bucket`, `intended_editions`, `source_*` and `compatibility_status`, `risk_level`, promotion fields, reviewer metadata, and related manifest ids) while preserving and normalizing the preexisting entries.
- Add `ash-archive/tools/lib/sourced_mods.py` to validate required fields, enums, kebab-case ids, list/str typing, and to return friendly `[ERROR] ...` messages rather than stack traces.
- Update `ash-archive/tools/summarize_sourced_mods.py` to validate the sourced-mod file (support `--file`), exit nonzero on schema errors, group candidates by `thematic_bucket`, and print `candidate_status`, `intended_editions`, `compatibility_status`, `risk_level`, and `source_confidence` in a concise table.
- Add tests and fixtures under `ash-archive/tests/` covering valid/invalid fixtures, missing/invalid fields and kebab-case id checks, and confirm the summary tool returns nonzero for invalid input, plus a new `ash-archive/shared/sourced-mod-workflow.md` and a short `CONTRIBUTING.md` pointer describing the intake/promotion workflow.
- No large new sourced-mod batch was added and edition manifests were not modified as part of this change.

### Testing
- Ran `python tools/summarize_sourced_mods.py` against the updated `shared/sourced-mods.yaml` and it produced a grouped summary without errors.
- Ran repository checks `python tools/validate_manifests.py`, `python tools/check_duplicate_mods.py`, `python tools/compare_editions.py`, and `python tools/generate_modlist_markdown.py` and they completed successfully.
- Ran the test suite with `pytest` and all tests passed (`24 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed23bb5d908333b69b6140ee9b5ed2)