### PR TITLE
Fix sourced-mod schema mismatch after parallel merges

### DIFF
--- a/ash-archive/shared/sourced-mod-workflow.md
+++ b/ash-archive/shared/sourced-mod-workflow.md
@@ -2,6 +2,20 @@
 
 `shared/sourced-mods.yaml` is an **intake desk** for candidates, not a list of accepted mods.
 
+
+## Canonical YAML schema
+
+`shared/sourced-mods.yaml` must use a **top-level `sourced_candidates:` list**.
+
+```yaml
+sourced_candidates:
+  - id: example-mod-id
+    thematic_bucket: dream-sixth-house
+    # ...remaining required candidate fields
+```
+
+Do not use bucket-grouped shapes like `buckets: -> candidates:` in this file.
+
 ## Candidate intake
 
 For each sourced candidate:

--- a/ash-archive/shared/sourced-mods.yaml
+++ b/ash-archive/shared/sourced-mods.yaml
@@ -1,166 +1,152 @@
-buckets:
-  - name: dream-sixth-house
-    candidates:
-      - id: the-dream-is-the-door
-        name: The Dream is the Door
-        source: nexus
-        source_type: nexus
-        source_url: https://www.nexusmods.com/morrowind/mods/47423
-        source_confidence: verified
-        thematic_bucket: dream-sixth-house
-        intended_editions: [openmw, mwse]
-        compatibility_status: needs-testing
-        promotion_target: both
-        risk_level: medium
-        thematic_reason: Cavern of the Incarnate entrance becomes visible only at twilight, aligning prophecy and spatial access.
-        candidate_status: candidate
-        reviewed_by: []
-        last_reviewed: ""
-        related_manifest_ids: []
-        evidence_notes: Nexus page describes the Cavern of the Incarnate entrance becoming visible only at twilight.
-        engine_notes: Nexus page lists both OpenMW and MWSE tags.
-        promotion_notes: Verify quest progression behavior around Cavern of the Incarnate timing in both OpenMW and MWSE, and confirm no blockers for main-quest access.
+sourced_candidates:
+  - id: the-dream-is-the-door
+    name: The Dream is the Door
+    source_type: nexus
+    source_url: https://www.nexusmods.com/morrowind/mods/47423
+    source_confidence: verified
+    thematic_bucket: dream-sixth-house
+    intended_editions: [openmw, mwse]
+    compatibility_status: needs-testing
+    promotion_target: both
+    risk_level: medium
+    thematic_reason: Cavern of the Incarnate entrance becomes visible only at twilight, aligning prophecy and spatial access.
+    candidate_status: candidate
+    reviewed_by: []
+    last_reviewed: ""
+    related_manifest_ids: []
+    evidence_notes: Nexus page describes the Cavern of the Incarnate entrance becoming visible only at twilight.
+    engine_notes: Nexus page lists both OpenMW and MWSE tags.
+    promotion_notes: Verify quest progression behavior around Cavern of the Incarnate timing in both OpenMW and MWSE, and confirm no blockers for main-quest access.
 
-      - id: lucid-disturbing-dreams
-        name: Lucid Disturbing Dreams
-        source: nexus
-        source_type: nexus
-        source_url: https://www.nexusmods.com/morrowind/mods/55705
-        source_confidence: verified
-        thematic_bucket: dream-sixth-house
-        intended_editions: [openmw, mwse]
-        compatibility_status: needs-testing
-        promotion_target: both
-        risk_level: medium
-        thematic_reason: Converts Dagoth Ur’s four disturbing dream textboxes into voiced playable dream sequences.
-        candidate_status: candidate
-        reviewed_by: []
-        last_reviewed: ""
-        related_manifest_ids: []
-        evidence_notes: Nexus page states the four disturbing dream textboxes are replaced with voiced playable dream sequences.
-        engine_notes: Nexus page includes OpenMW and MWSE tags.
-        promotion_notes: Test each main-quest dream trigger, subtitle/audio behavior, and ensure no quest-state softlocks in either edition.
+  - id: lucid-disturbing-dreams
+    name: Lucid Disturbing Dreams
+    source_type: nexus
+    source_url: https://www.nexusmods.com/morrowind/mods/55705
+    source_confidence: verified
+    thematic_bucket: dream-sixth-house
+    intended_editions: [openmw, mwse]
+    compatibility_status: needs-testing
+    promotion_target: both
+    risk_level: medium
+    thematic_reason: Converts Dagoth Ur’s four disturbing dream textboxes into voiced playable dream sequences.
+    candidate_status: candidate
+    reviewed_by: []
+    last_reviewed: ""
+    related_manifest_ids: []
+    evidence_notes: Nexus page states the four disturbing dream textboxes are replaced with voiced playable dream sequences.
+    engine_notes: Nexus page includes OpenMW and MWSE tags.
+    promotion_notes: Test each main-quest dream trigger, subtitle/audio behavior, and ensure no quest-state softlocks in either edition.
 
-      - id: beware-the-sixth-house
-        name: Beware the Sixth House
-        source: nexus
-        source_type: nexus
-        source_url: https://www.nexusmods.com/morrowind/mods/46036
-        source_confidence: verified
-        thematic_bucket: dream-sixth-house
-        intended_editions: [openmw, mwse]
-        compatibility_status: needs-testing
-        promotion_target: both
-        risk_level: high
-        thematic_reason: Makes Sixth House enemies significantly more dangerous; strong horror fit, but difficulty/pacing risk is high.
-        candidate_status: candidate
-        reviewed_by: []
-        last_reviewed: ""
-        related_manifest_ids: []
-        evidence_notes: Nexus page presents this as an overhaul that makes Sixth House enemies more dangerous.
-        engine_notes: Nexus page has no explicit hard engine requirement beyond Morrowind.
-        promotion_notes: Run balance passes in early/mid/late Sixth House encounters for both editions and check for pacing spikes or unavoidable difficulty walls.
+  - id: beware-the-sixth-house
+    name: Beware the Sixth House
+    source_type: nexus
+    source_url: https://www.nexusmods.com/morrowind/mods/46036
+    source_confidence: verified
+    thematic_bucket: dream-sixth-house
+    intended_editions: [openmw, mwse]
+    compatibility_status: needs-testing
+    promotion_target: both
+    risk_level: high
+    thematic_reason: Makes Sixth House enemies significantly more dangerous; strong horror fit, but difficulty/pacing risk is high.
+    candidate_status: candidate
+    reviewed_by: []
+    last_reviewed: ""
+    related_manifest_ids: []
+    evidence_notes: Nexus page presents this as an overhaul that makes Sixth House enemies more dangerous.
+    engine_notes: Nexus page has no explicit hard engine requirement beyond Morrowind.
+    promotion_notes: Run balance passes in early/mid/late Sixth House encounters for both editions and check for pacing spikes or unavoidable difficulty walls.
 
-      - id: kogoruhn-extinct-city-of-ash-and-sulfur
-        name: Kogoruhn - Extinct City of Ash and Sulfur
-        source: nexus
-        source_type: nexus
-        source_url: https://www.nexusmods.com/morrowind/mods/51615
-        source_confidence: verified
-        thematic_bucket: dream-sixth-house
-        intended_editions: [openmw, mwse]
-        compatibility_status: needs-testing
-        promotion_target: both
-        risk_level: high
-        thematic_reason: Turns Kogoruhn into a larger Sixth House horror/location centerpiece; likely central but requires compatibility testing.
-        candidate_status: candidate
-        reviewed_by: []
-        last_reviewed: ""
-        related_manifest_ids: []
-        evidence_notes: Nexus page describes a major Kogoruhn location overhaul themed around ash and sulfur.
-        engine_notes: Nexus page does not clearly state OpenMW/MWSE-only requirements.
-        promotion_notes: Validate compatibility with quest routing, pathing, and major dungeon/location edits in both editions before promotion.
+  - id: kogoruhn-extinct-city-of-ash-and-sulfur
+    name: Kogoruhn - Extinct City of Ash and Sulfur
+    source_type: nexus
+    source_url: https://www.nexusmods.com/morrowind/mods/51615
+    source_confidence: verified
+    thematic_bucket: dream-sixth-house
+    intended_editions: [openmw, mwse]
+    compatibility_status: needs-testing
+    promotion_target: both
+    risk_level: high
+    thematic_reason: Turns Kogoruhn into a larger Sixth House horror/location centerpiece; likely central but requires compatibility testing.
+    candidate_status: candidate
+    reviewed_by: []
+    last_reviewed: ""
+    related_manifest_ids: []
+    evidence_notes: Nexus page describes a major Kogoruhn location overhaul themed around ash and sulfur.
+    engine_notes: Nexus page does not clearly state OpenMW/MWSE-only requirements.
+    promotion_notes: Validate compatibility with quest routing, pathing, and major dungeon/location edits in both editions before promotion.
 
-  - name: blight-ash-weather
-    candidates:
-      - id: creeping-blight
-        name: Creeping Blight
-        source: nexus
-        source_type: nexus
-        source_url: https://www.nexusmods.com/morrowind/mods/47904
-        source_confidence: verified
-        thematic_bucket: blight-ash-weather
-        intended_editions: [openmw, mwse]
-        compatibility_status: needs-testing
-        promotion_target: both
-        risk_level: medium
-        thematic_reason: Blight weather expands with main quest progress and, in MWSE, elapsed time.
-        candidate_status: candidate
-        reviewed_by: []
-        last_reviewed: ""
-        related_manifest_ids: []
-        evidence_notes: Nexus page describes blight weather expansion linked to main quest progress, with MWSE time-based expansion support.
-        engine_notes: Nexus page indicates support for OpenMW and MWSE behavior paths.
-        promotion_notes: Confirm weather progression logic and regional intensity in both editions, including MWSE elapsed-time behavior where applicable.
+  - id: creeping-blight
+    name: Creeping Blight
+    source_type: nexus
+    source_url: https://www.nexusmods.com/morrowind/mods/47904
+    source_confidence: verified
+    thematic_bucket: blight-ash-weather
+    intended_editions: [openmw, mwse]
+    compatibility_status: needs-testing
+    promotion_target: both
+    risk_level: medium
+    thematic_reason: Blight weather expands with main quest progress and, in MWSE, elapsed time.
+    candidate_status: candidate
+    reviewed_by: []
+    last_reviewed: ""
+    related_manifest_ids: []
+    evidence_notes: Nexus page describes blight weather expansion linked to main quest progress, with MWSE time-based expansion support.
+    engine_notes: Nexus page indicates support for OpenMW and MWSE behavior paths.
+    promotion_notes: Confirm weather progression logic and regional intensity in both editions, including MWSE elapsed-time behavior where applicable.
 
-      - id: it-beats-openmw
-        name: It Beats OpenMW
-        source: nexus
-        source_type: nexus
-        source_url: https://www.nexusmods.com/morrowind/mods/57396
-        source_confidence: verified
-        thematic_bucket: blight-ash-weather
-        intended_editions: [openmw]
-        compatibility_status: needs-testing
-        promotion_target: openmw
-        risk_level: medium
-        thematic_reason: Adds OpenMW Red Mountain heartbeat ambience.
-        candidate_status: candidate
-        reviewed_by: []
-        last_reviewed: ""
-        related_manifest_ids: []
-        evidence_notes: Nexus page describes Red Mountain heartbeat ambience implementation for OpenMW.
-        engine_notes: Nexus page clearly identifies OpenMW-only target.
-        promotion_notes: Validate ambient trigger zones, volume balance, and interaction with weather/audio mods in OpenMW.
+  - id: it-beats-openmw
+    name: It Beats OpenMW
+    source_type: nexus
+    source_url: https://www.nexusmods.com/morrowind/mods/57396
+    source_confidence: verified
+    thematic_bucket: blight-ash-weather
+    intended_editions: [openmw]
+    compatibility_status: needs-testing
+    promotion_target: openmw
+    risk_level: medium
+    thematic_reason: Adds OpenMW Red Mountain heartbeat ambience.
+    candidate_status: candidate
+    reviewed_by: []
+    last_reviewed: ""
+    related_manifest_ids: []
+    evidence_notes: Nexus page describes Red Mountain heartbeat ambience implementation for OpenMW.
+    engine_notes: Nexus page clearly identifies OpenMW-only target.
+    promotion_notes: Validate ambient trigger zones, volume balance, and interaction with weather/audio mods in OpenMW.
 
-      - id: heartthrum
-        name: Heartthrum
-        source: nexus
-        source_type: nexus
-        source_url: https://www.nexusmods.com/morrowind/mods/47178
-        source_confidence: verified
-        thematic_bucket: blight-ash-weather
-        intended_editions: [mwse]
-        compatibility_status: needs-testing
-        promotion_target: mwse
-        risk_level: medium
-        thematic_reason: MWSE/MGE XE Red Mountain heartbeat ambience.
-        candidate_status: candidate
-        reviewed_by: []
-        last_reviewed: ""
-        related_manifest_ids: []
-        evidence_notes: Nexus page describes Red Mountain heartbeat ambience for MWSE/MGE XE setups.
-        engine_notes: Nexus page indicates MWSE and MGE XE requirements.
-        promotion_notes: Verify heartbeat ambience triggers and performance with MWSE-heavy stacks and regional weather/audio combinations.
+  - id: heartthrum
+    name: Heartthrum
+    source_type: nexus
+    source_url: https://www.nexusmods.com/morrowind/mods/47178
+    source_confidence: verified
+    thematic_bucket: blight-ash-weather
+    intended_editions: [mwse]
+    compatibility_status: needs-testing
+    promotion_target: mwse
+    risk_level: medium
+    thematic_reason: MWSE/MGE XE Red Mountain heartbeat ambience.
+    candidate_status: candidate
+    reviewed_by: []
+    last_reviewed: ""
+    related_manifest_ids: []
+    evidence_notes: Nexus page describes Red Mountain heartbeat ambience for MWSE/MGE XE setups.
+    engine_notes: Nexus page indicates MWSE and MGE XE requirements.
+    promotion_notes: Verify heartbeat ambience triggers and performance with MWSE-heavy stacks and regional weather/audio combinations.
 
-  - name: survival-body-horror
-    candidates:
-      - id: ashfall
-        name: Ashfall
-        source: nexus
-        source_type: nexus
-        source_url: https://www.nexusmods.com/morrowind/mods/49057
-        source_confidence: verified
-        thematic_bucket: survival-body-horror
-        intended_editions: [mwse]
-        compatibility_status: needs-testing
-        promotion_target: mwse
-        risk_level: high
-        thematic_reason: MWSE survival/camping/needs system; supports Sleeper Edition’s body/travel pressure if configured carefully.
-        candidate_status: candidate
-        reviewed_by: []
-        last_reviewed: ""
-        related_manifest_ids: []
-        evidence_notes: Nexus page describes survival mechanics including needs and camping systems.
-        engine_notes: Nexus page specifies MWSE dependency.
-        promotion_notes: Stress-test survival loop settings, UI flow, and compatibility with travel/economy mods in MWSE before any promotion.
+  - id: ashfall
+    name: Ashfall
+    source_type: nexus
+    source_url: https://www.nexusmods.com/morrowind/mods/49057
+    source_confidence: verified
+    thematic_bucket: survival-body-horror
+    intended_editions: [mwse]
+    compatibility_status: needs-testing
+    promotion_target: mwse
+    risk_level: high
+    thematic_reason: MWSE survival/camping/needs system; supports Sleeper Edition’s body/travel pressure if configured carefully.
+    candidate_status: candidate
+    reviewed_by: []
+    last_reviewed: ""
+    related_manifest_ids: []
+    evidence_notes: Nexus page describes survival mechanics including needs and camping systems.
+    engine_notes: Nexus page specifies MWSE dependency.
+    promotion_notes: Stress-test survival loop settings, UI flow, and compatibility with travel/economy mods in MWSE before any promotion.


### PR DESCRIPTION
### Motivation
- The shared sourced-mods file used a `buckets: -> candidates:` grouping while the validator and summary tooling expect a top-level `sourced_candidates:` list, causing validation and summary to fail after parallel merges. 

### Description
- Converted `ash-archive/shared/sourced-mods.yaml` from the bucket-grouped shape to a top-level `sourced_candidates:` list and flattened each candidate into an entry with `thematic_bucket` preserved. 
- Preserved all eight Phase 1 candidates and their metadata fields (`source_url`, `source_confidence`, `intended_editions`, `compatibility_status`, `promotion_target`, `risk_level`, `thematic_reason`, `evidence_notes`, `engine_notes`, `promotion_notes`, `reviewed_by`, `last_reviewed`, `related_manifest_ids`). 
- Removed obsolete duplicate `source` fields in favor of the canonical `source_type` field and updated `ash-archive/shared/sourced-mod-workflow.md` to document the exact canonical schema shape. 
- Files changed: `ash-archive/shared/sourced-mods.yaml` and `ash-archive/shared/sourced-mod-workflow.md`.
- Exact schema decision made: the canonical shape is a top-level `sourced_candidates:` list of candidate objects, e.g.

```yaml
sourced_candidates:
  - id: example-mod-id
    thematic_bucket: dream-sixth-house
    # ...remaining required candidate fields
```

and `buckets:` with nested `candidates:` is no longer valid for `shared/sourced-mods.yaml`.

### Testing
- Ran the requested validation and reporting commands from `ash-archive/`: `python tools/summarize_sourced_mods.py`, `python tools/validate_manifests.py`, `python tools/check_duplicate_mods.py`, `python tools/compare_editions.py`, and `python tools/generate_modlist_markdown.py`, and each completed successfully. 
- Ran `pytest` which executed the test suite and passed (24 tests passed). 
- Confirmations: all eight Phase 1 candidates were preserved (`the-dream-is-the-door`, `lucid-disturbing-dreams`, `beware-the-sixth-house`, `kogoruhn-extinct-city-of-ash-and-sulfur`, `creeping-blight`, `it-beats-openmw`, `heartthrum`, `ashfall`), no edition manifests were changed (edition manifest files were not edited), and no candidates were promoted or accepted as part of this change. 
- Remaining uncertainties: none identified; the schema and tooling now agree on `sourced_candidates` as the top-level shape.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed283b16648333ba3acfe22c144cd4)