### PR TITLE
docs: clarify roadmap progress and phase exit criteria

### DIFF
--- a/ash-archive/ROADMAP.md
+++ b/ash-archive/ROADMAP.md
@@ -1,16 +1,65 @@
 # Roadmap
 
-## Phase 0 - Scaffold (current)
-- Establish schema, manifests, docs, and validation tools.
+## Current state (April 2026)
+- Repository foundation is in place: dual-edition structure, schema-backed manifests, baseline docs, and validation/generation tooling.
+- Project remains **planning/scaffold**, not yet an installable or fully playable Wabbajack list.
 
-## Phase 1 - Sourcing
-- Fill candidate pools with verified source metadata.
+## Phase 0 - Scaffold (completed)
+**Goal:** establish guardrails before content scaling.
+
+Completed outcomes:
+- Shared and per-edition manifest layout defined.
+- Validation and consistency tooling established.
+- Baseline documentation created for setup, policy, and testing flow.
+
+## Phase 1 - Sourcing (active)
+**Goal:** build trustworthy candidate pools with traceable provenance.
+
+In-scope work:
+- Expand `shared/sourced-mods.yaml` with verified metadata and source links.
+- Keep triage and package metadata synchronized (`shared/source-triage.yaml`, `shared/source-package-meta.yaml`).
+- Track rejected options with retained reasoning.
+
+Exit criteria:
+- Candidate pools are sufficiently populated across major categories for both editions.
+- Validation passes with no structural issues.
+- Source provenance and decision notes are present for all active candidates.
 
 ## Phase 2 - Evaluation
-- Test by category and route; document decisions.
+**Goal:** convert sourced candidates into evidence-based accept/reject decisions.
+
+In-scope work:
+- Evaluate by category and test route using the shared rubric.
+- Record compatibility notes, conflicts, and mitigation paths.
+- Promote tested entries into edition manifests; document rejections with rationale.
+
+Exit criteria:
+- Core categories have evaluated coverage for both editions.
+- Major conflicts are either resolved or explicitly deferred with notes.
+- Accepted entries include compatibility evidence.
 
 ## Phase 3 - Edition hardening
-- Build stable release checklists and patch strategy.
+**Goal:** stabilize each edition as a coherent, testable package.
 
-## Phase 4 - Wabbajack release prep
-- Freeze manifests and produce installable lists.
+In-scope work:
+- Lock edition-level load-order policy enforcement.
+- Finalize patch strategy and external tool requirements.
+- Run repeated validation and checklist cycles for regression control.
+
+Exit criteria:
+- Both editions have internally consistent manifests and patch plans.
+- Known issues are documented with severity and workarounds.
+- Release checklists are actionable and reproducible.
+
+## Phase 4 - Wabbajack release preparation
+**Goal:** ship installable builds with clear support boundaries.
+
+In-scope work:
+- Freeze manifests for release candidates.
+- Produce final modlist exports and installer-facing documentation.
+- Perform end-to-end install tests and capture support notes.
+
+Exit criteria:
+- Install flow succeeds for each edition using documented steps.
+- Release notes and known issues are published.
+- Versioned release artifacts are ready for distribution.


### PR DESCRIPTION
### Motivation
- Make project status explicit by adding a dated “Current state (April 2026)” section and reinforcing that the repo is still planning/scaffold. 
- Provide clearer phase semantics by marking Phase 0 completed and Phase 1 active so work ownership and progress are visible. 
- Introduce concrete goals, in-scope work, and exit criteria to make phase transitions measurable and actionable.

### Description
- Rewrote `ash-archive/ROADMAP.md` from a brief phase list into an expanded roadmap with a current-state summary. 
- Marked `Phase 0` as completed and `Phase 1` as active and added explicit `Goal` and `In-scope work` for phases 1–4. 
- Added `Exit criteria` for Phases 1–4 so progress can be validated before advancing. 
- This is a documentation-only change limited to `ash-archive/ROADMAP.md` with no code or manifest modifications.

### Testing
- Ran `git -C /workspace/AshArchive diff -- ash-archive/ROADMAP.md` to confirm the intended changes were staged and displayed as expected. 
- Ran `git -C /workspace/AshArchive status --short --branch` to verify the repository state and that the change was committed. 
- The change was committed successfully with message `docs: expand roadmap with phase goals and exit criteria`. 
- Did not run the full test suite or validation scripts because this is a docs-only update and no runtime or manifest behavior was changed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0080912448333bf46981eaf001bd0)