### PR TITLE
Rename manifest YAML loader to metadata-oriented name

### DIFF
--- a/ash-archive/tools/lib/manifest.py
+++ b/ash-archive/tools/lib/manifest.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import yaml
 
 
-def load_yaml(path: Path) -> dict:
+def load_meta_document(path: Path) -> dict:
     try:
         with path.open("r", encoding="utf-8") as handle:
             data = yaml.safe_load(handle) or {}
@@ -20,7 +20,7 @@ def load_yaml(path: Path) -> dict:
 
 
 def load_mods(path: Path) -> list[dict]:
-    data = load_yaml(path)
+    data = load_meta_document(path)
     mods = data.get("mods", [])
     if not isinstance(mods, list):
         raise ValueError(f"'mods' must be a list: {path}")

--- a/ash-archive/tools/lib/sourced_mods.py
+++ b/ash-archive/tools/lib/sourced_mods.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
-from .manifest import load_yaml
+from .manifest import load_meta_document
 
 ID_RE = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
 
@@ -154,7 +154,7 @@ def validate_candidate(candidate: dict, path: Path) -> list[str]:
 
 
 def load_sourced_candidates(path: Path) -> list[dict]:
-    data = load_yaml(path)
+    data = load_meta_document(path)
     candidates = data.get("sourced_candidates")
     if not isinstance(candidates, list):
         raise ValueError(f"Top-level key 'sourced_candidates' must be a list: {path}")

--- a/ash-archive/tools/lib/validation.py
+++ b/ash-archive/tools/lib/validation.py
@@ -4,7 +4,7 @@ import re
 from functools import lru_cache
 from pathlib import Path
 
-from .manifest import load_mods, load_yaml
+from .manifest import load_mods, load_meta_document
 from .paths import categories_path
 
 ID_RE = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
@@ -64,7 +64,7 @@ def _format_error(path: Path, mod_ref: str, detail: str) -> str:
 
 @lru_cache(maxsize=1)
 def _allowed_categories() -> frozenset[str]:
-    data = load_yaml(categories_path())
+    data = load_meta_document(categories_path())
     cats = data.get("categories", [])
     if not isinstance(cats, list):
         raise ValueError(f"Top-level key 'categories' must be a list: {categories_path()}")


### PR DESCRIPTION
### Motivation
- Clarify intent of the YAML loader by giving it a metadata-oriented name to better reflect its use for `.meta`/manifest documents.
- Keep parsing and error semantics unchanged while making the API name more descriptive.

### Description
- Renamed `load_yaml` to `load_meta_document` in `ash-archive/tools/lib/manifest.py` and left `yaml.safe_load` and existing validation/error handling intact.
- Updated `load_mods` to call `load_meta_document` instead of the old name.
- Updated imports and call sites to use `load_meta_document` in `ash-archive/tools/lib/validation.py` and `ash-archive/tools/lib/sourced_mods.py`.
- Per request, performed a full rename with no backward-compatibility alias added.

### Testing
- Ran `rg "load_yaml|load_meta_document" -n ash-archive/tools/lib` to verify usages were updated and the old name removed.
- Ran `python -m compileall ash-archive/tools/lib/manifest.py ash-archive/tools/lib/validation.py ash-archive/tools/lib/sourced_mods.py` and compilation succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f27bb792408333b2dacfc1320722ef)