### PR TITLE
Clarify metadata extension and YAML format language in shared docs

### DIFF
--- a/ash-archive/shared/mod-meta-schema.md
+++ b/ash-archive/shared/mod-meta-schema.md
@@ -8,8 +8,8 @@ Internal control metadata `.control.meta` files provide deterministic, machine-r
 
 ## File format and naming
 
-- Format: YAML
-- Extension: `.control.meta`
+- Content format: YAML-structured metadata documents.
+- File-extension convention in this repository: `.meta` (this schema specifically uses `.control.meta`).
 - Naming pattern: `<slug>-<source_id>.control.meta`
   - For Nexus-backed rows, `source_id` is the numeric `nexus_id`.
   - For non-Nexus rows (`Unmanaged:*`, `DLC:*`, and rows without a Nexus ID), use `local`.

--- a/ash-archive/shared/sourced-mod-workflow.md
+++ b/ash-archive/shared/sourced-mod-workflow.md
@@ -3,7 +3,9 @@
 `shared/sourced-mods.control.meta` is an **intake desk** for candidates, not a list of accepted mods. It is internal control metadata and **not** an MO2 download sidecar `.meta` file.
 
 
-## Canonical YAML schema
+## Canonical YAML content schema (`.meta` extension convention)
+
+In this repository, `.meta` is the file-extension convention for metadata documents (including `.control.meta` variants). The file content remains YAML-structured.
 
 `shared/sourced-mods.control.meta` must use a **top-level `sourced_candidates:` list**.
 


### PR DESCRIPTION
### Motivation
- Prevent ambiguity between file-extension conventions and document content format by making `.meta` vs YAML wording explicit in shared metadata docs.

### Description
- Update `ash-archive/shared/sourced-mod-workflow.md` to change the heading to "Canonical YAML content schema (`.meta` extension convention)" and add text stating that `.meta` is the repository file-extension convention while the document content remains YAML-structured. 
- Update `ash-archive/shared/mod-meta-schema.md` under "File format and naming" to state the content is YAML-structured and that the repo uses a `.meta` file-extension convention (this schema uses `.control.meta`).
- Record the changes in a commit with the message `Clarify .meta extension vs YAML content wording`.

### Testing
- Ran `git diff -- ash-archive/shared/sourced-mod-workflow.md ash-archive/shared/mod-meta-schema.md` to validate the diff and it returned the expected changes. 
- Committed the changes with `git add`/`git commit` which completed successfully. 
- Displayed the updated files with `nl -ba` to verify the updated headings and bullets, which showed the intended wording. 
- Created PR metadata via the `make_pr` tool which returned the PR title and body successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f27c1249f0833392f6df8189427795)