### PR TITLE
Add test coverage for metadata filename conventions

### DIFF
--- a/ash-archive/tests/test_meta_filename_conventions.py
+++ b/ash-archive/tests/test_meta_filename_conventions.py
@@ -1,0 +1,42 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+REQUIRED_META_FILES = [
+    # Shared metadata
+    "shared/categories.control.meta",
+    "shared/sourced-mods.control.meta",
+    "shared/source-triage.control.meta",
+    "shared/source-package-meta.control.meta",
+    # OpenMW edition manifests
+    "editions/openmw/manifests/mods.control.meta",
+    "editions/openmw/manifests/load-order.control.meta",
+    "editions/openmw/manifests/external-tools.control.meta",
+    "editions/openmw/manifests/patches.control.meta",
+    "editions/openmw/manifests/rejected-mods.control.meta",
+    # MWSE edition manifests
+    "editions/mwse/manifests/mods.control.meta",
+    "editions/mwse/manifests/load-order.control.meta",
+    "editions/mwse/manifests/external-tools.control.meta",
+    "editions/mwse/manifests/patches.control.meta",
+    "editions/mwse/manifests/rejected-mods.control.meta",
+    # Test fixtures
+    "tests/fixtures/valid_mods.control.meta",
+    "tests/fixtures/invalid_mods.control.meta",
+    "tests/fixtures/valid_sourced_mods.control.meta",
+    "tests/fixtures/invalid_sourced_mods.control.meta",
+]
+
+
+def test_required_meta_files_exist() -> None:
+    for rel_path in REQUIRED_META_FILES:
+        meta_path = ROOT / rel_path
+        assert meta_path.exists(), f"missing metadata file: {rel_path}"
+
+
+def test_legacy_yaml_counterparts_do_not_exist() -> None:
+    for rel_path in REQUIRED_META_FILES:
+        meta_path = ROOT / rel_path
+        yaml_path = meta_path.with_suffix(".yaml")
+        assert not yaml_path.exists(), f"legacy YAML file still present: {yaml_path}"


### PR DESCRIPTION
### Motivation
- Provide a fast CI signal to detect regressions in internal metadata filename conventions for edition manifests, shared metadata, and test fixtures.
- Ensure the repository uses the expected `.meta` naming and that legacy `.yaml` counterparts are not reintroduced.

### Description
- Add a new pytest module at `ash-archive/tests/test_meta_filename_conventions.py` that enumerates required metadata paths and verifies they exist using `Path.exists()`.
- Verify legacy YAML counterparts are absent by checking `Path.with_suffix(".yaml")` does not exist for each known `.meta` file.
- The test covers shared metadata, edition manifests for `openmw` and `mwse`, and test fixtures.

### Testing
- Ran `pytest -q ash-archive/tests/test_meta_filename_conventions.py` which executed the new tests.
- Result: `2 passed` (tests succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f27c17b3fc833384f4690c73b2aca7)