### PR TITLE
Add filesystem-only tests for canonical .meta filename conventions

### DIFF
--- a/ash-archive/tests/test_meta_filename_conventions.py
+++ b/ash-archive/tests/test_meta_filename_conventions.py
@@ -3,40 +3,41 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 
-REQUIRED_META_FILES = [
-    # Shared metadata
-    "shared/categories.control.meta",
-    "shared/sourced-mods.control.meta",
-    "shared/source-triage.control.meta",
-    "shared/source-package-meta.control.meta",
-    # OpenMW edition manifests
-    "editions/openmw/manifests/mods.control.meta",
-    "editions/openmw/manifests/load-order.control.meta",
-    "editions/openmw/manifests/external-tools.control.meta",
-    "editions/openmw/manifests/patches.control.meta",
-    "editions/openmw/manifests/rejected-mods.control.meta",
-    # MWSE edition manifests
-    "editions/mwse/manifests/mods.control.meta",
-    "editions/mwse/manifests/load-order.control.meta",
-    "editions/mwse/manifests/external-tools.control.meta",
-    "editions/mwse/manifests/patches.control.meta",
-    "editions/mwse/manifests/rejected-mods.control.meta",
-    # Test fixtures
-    "tests/fixtures/valid_mods.control.meta",
-    "tests/fixtures/invalid_mods.control.meta",
-    "tests/fixtures/valid_sourced_mods.control.meta",
-    "tests/fixtures/invalid_sourced_mods.control.meta",
+SHARED_META_FILES = [
+    "shared/categories.meta",
+    "shared/sourced-mods.meta",
+    "shared/source-triage.meta",
+    "shared/source-package-meta.meta",
 ]
 
 
-def test_required_meta_files_exist() -> None:
-    for rel_path in REQUIRED_META_FILES:
-        meta_path = ROOT / rel_path
-        assert meta_path.exists(), f"missing metadata file: {rel_path}"
+def _to_legacy_yaml_path(meta_path: Path) -> Path:
+    return meta_path.with_suffix(".yaml")
 
 
-def test_legacy_yaml_counterparts_do_not_exist() -> None:
-    for rel_path in REQUIRED_META_FILES:
+def test_expected_meta_files_exist() -> None:
+    edition_manifest_meta = sorted(
+        ROOT.glob("editions/*/manifests/*.meta"),
+    )
+    fixture_meta = sorted(
+        ROOT.glob("tests/fixtures/*.meta"),
+    )
+
+    assert edition_manifest_meta, "expected .meta files under editions/*/manifests/"
+    assert fixture_meta, "expected .meta fixtures under tests/fixtures/"
+
+    for rel_path in SHARED_META_FILES:
         meta_path = ROOT / rel_path
-        yaml_path = meta_path.with_suffix(".yaml")
+        assert meta_path.exists(), f"missing shared metadata file: {rel_path}"
+
+
+def test_legacy_yaml_equivalents_absent() -> None:
+    canonical_meta_paths = [ROOT / rel_path for rel_path in SHARED_META_FILES]
+    canonical_meta_paths.extend(ROOT.glob("editions/*/manifests/*.meta"))
+    canonical_meta_paths.extend(ROOT.glob("tests/fixtures/*.meta"))
+
+    assert canonical_meta_paths, "no canonical .meta files discovered"
+
+    for meta_path in canonical_meta_paths:
+        yaml_path = _to_legacy_yaml_path(meta_path)
         assert not yaml_path.exists(), f"legacy YAML file still present: {yaml_path}"


### PR DESCRIPTION
### Motivation
- Enforce a canonical `.meta` filename convention and catch lingering legacy names without parsing file contents for speed and stability.
- Verify presence of edition manifests and fixture metadata in `editions/*/manifests` and `tests/fixtures` and specific shared metadata paths.

### Description
- Add `ash-archive/tests/test_meta_filename_conventions.py` implementing filesystem-only checks that use globbing and path existence.
- Expect canonical shared files at `shared/categories.meta`, `shared/sourced-mods.meta`, `shared/source-triage.meta`, and `shared/source-package-meta.meta` and require at least one `editions/*/manifests/*.meta` and `tests/fixtures/*.meta`.
- Assert legacy YAML equivalents are absent by checking each discovered canonical path with the helper `_to_legacy_yaml_path`.
- No file parsing is performed; checks use only `Path.exists()` and `Path.glob()`.

### Testing
- Ran `pytest -q ash-archive/tests/test_meta_filename_conventions.py` as the automated verification step.
- Result: 1 failed, 1 passed; the failure is expected because the repository currently uses `*.control.meta` names for shared files rather than the new canonical `*.meta` names.
- The test run confirms the test exercises both presence checks and legacy-absence assertions and completes quickly due to being filesystem-only.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f27d469d448333bc3256b559c4f313)