### PR TITLE
docs: clarify `.meta` extension and YAML-structured content across contributor docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,7 +77,7 @@ Use a subset only when truly scope-limited; state what was run.
 
 ## Manifest change expectations
 
-Internal control metadata uses YAML `.control.meta` files for project tooling. These are separate from MO2 download sidecar `.meta` files and must not be represented as native sidecars.
+Internal control metadata files use the `.meta` extension (commonly `.control.meta`) and remain YAML-structured for project tooling. These are separate from MO2 download sidecar `.meta` files and must not be represented as native sidecars.
 
 When editing manifests:
 

--- a/ash-archive/ROADMAP.md
+++ b/ash-archive/ROADMAP.md
@@ -16,7 +16,7 @@ Completed outcomes:
 **Goal:** build trustworthy candidate pools with traceable provenance.
 
 In-scope work:
-- Expand `shared/sourced-mods.control.meta` with verified metadata and source links.
+- Expand `shared/sourced-mods.control.meta` (.meta extension, YAML-structured content) with verified metadata and source links.
 - Keep triage and package metadata synchronized (`shared/source-triage.control.meta`, `shared/source-package-meta.control.meta`).
 - Track rejected options with retained reasoning.
 

--- a/ash-archive/shared/mod-meta-schema.md
+++ b/ash-archive/shared/mod-meta-schema.md
@@ -8,8 +8,8 @@ Internal control metadata `.control.meta` files provide deterministic, machine-r
 
 ## File format and naming
 
-- Content format: YAML-structured metadata documents.
-- File-extension convention in this repository: `.meta` (this schema specifically uses `.control.meta`).
+- Files use the `.meta` extension (this schema specifically uses `.control.meta`).
+- Content remains YAML-structured metadata.
 - Naming pattern: `<slug>-<source_id>.control.meta`
   - For Nexus-backed rows, `source_id` is the numeric `nexus_id`.
   - For non-Nexus rows (`Unmanaged:*`, `DLC:*`, and rows without a Nexus ID), use `local`.

--- a/ash-archive/shared/sourced-mod-workflow.md
+++ b/ash-archive/shared/sourced-mod-workflow.md
@@ -3,9 +3,9 @@
 `shared/sourced-mods.control.meta` is an **intake desk** for candidates, not a list of accepted mods. It is internal control metadata and **not** an MO2 download sidecar `.meta` file.
 
 
-## Canonical YAML content schema (`.meta` extension convention)
+## Canonical metadata format (`.meta` extension, YAML-structured content)
 
-In this repository, `.meta` is the file-extension convention for metadata documents (including `.control.meta` variants). The file content remains YAML-structured.
+In this repository, metadata files use the `.meta` extension (including `.control.meta` variants). Content remains YAML-structured.
 
 `shared/sourced-mods.control.meta` must use a **top-level `sourced_candidates:` list**.
 


### PR DESCRIPTION
### Motivation
- Clarify the repository's intent that metadata files use the `.meta` extension while their content remains YAML-structured to avoid confusion between internal control metadata and MO2/Wabbajack sidecar files. 
- Align contributor-facing documentation so reviewers and tooling authors use consistent terminology when discussing file naming and data format.

### Description
- Updated `ash-archive/shared/sourced-mod-workflow.md` to revise the canonical format heading and text to state that metadata files use the `.meta` extension and content remains YAML-structured. 
- Updated `ash-archive/shared/mod-meta-schema.md` in the **File format and naming** section to use the same `.meta` extension + YAML-structured wording model. 
- Updated `CONTRIBUTING.md` to align the manifest expectations wording to explicitly mention `.meta` extension usage and YAML-structured content. 
- Updated `ash-archive/ROADMAP.md` to make Phase 1 sourcing guidance consistent with the `.meta` extension and YAML-structured content phrasing. 

### Testing
- Verified the changes with a targeted diff of the touched files using `git diff` to confirm the intended edits. 
- Confirmed the working tree is clean with `git status --short` after applying edits. 
- No runtime or schema tests were required because this is a docs-only change and no code or validation behavior was modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f27d46e5d48333809b0bf778b172ec)