### PR TITLE
Plan local agent presets

### DIFF
--- a/AGENT-RULES.md
+++ b/AGENT-RULES.md
@@ -9,6 +9,7 @@ These rules apply to AI assistants (Codex, Copilot, Claude, and similar agents) 
 3. Limit scope to the requested task; do not bundle unrelated feature work.
 4. When uncertain, document uncertainty explicitly instead of guessing.
 5. Run relevant validation commands before opening or updating a PR.
+6. Use `ash-archive/LOCAL-AGENT-PRESETS.md` when configuring or running local agents for recurring automated tasks.
 
 ## Repository direction and design constraints
 

--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ pytest
 - [Pilgrim Edition](ash-archive/editions/openmw/README.md) — OpenMW edition identity and scope
 - [Sleeper Edition](ash-archive/editions/mwse/README.md) — MWSE edition identity and scope
 - [Changelog](ash-archive/CHANGELOG.md)
+- [Local Agent Presets](ash-archive/LOCAL-AGENT-PRESETS.md) — planned presets for safe automated maintenance tasks
 
 ---
 

--- a/ash-archive/LOCAL-AGENT-PRESETS.md
+++ b/ash-archive/LOCAL-AGENT-PRESETS.md
@@ -1,0 +1,202 @@
+# Local Agent Presets
+
+This document plans reusable local agent presets for routine Ash Archive maintenance. The presets are intentionally conservative: agents may prepare evidence, apply mechanical updates, and run validation, but they must not invent provenance, compatibility evidence, or release readiness.
+
+## Shared operating rules
+
+Every preset must follow these baseline constraints before doing specialized work:
+
+- Read `../AGENT-RULES.md`, `PROJECT-BIBLE.md`, and the relevant edition or shared documentation before editing.
+- Keep changes small, branch-scoped, and reviewable.
+- Treat all `.control.meta` files as internal YAML control metadata, not Mod Organizer 2 download sidecars.
+- Never synthesize source URLs, archive names, version numbers, Nexus IDs, compatibility claims, or test results.
+- Leave uncertain entries marked `unverified`, `needs-testing`, `planned`, or `blocked` as appropriate.
+- Preserve rejected records and their reasoning.
+- Run only the validation commands relevant to the files touched, then report commands that were skipped and why.
+
+## Preset matrix
+
+| Preset | Main purpose | Primary files | Safe automation level | Required checks |
+|---|---|---|---|---|
+| `source-triage-agent` | Turn open sourcing questions into evidence-backed triage notes. | `shared/source-triage.control.meta`, `shared/sourced-mods.control.meta`, `shared/source-package-meta.control.meta` | Draft and annotate only; do not promote candidates. | `python tools/validate_manifests.py`, `pytest tests/test_sourced_mods.py` |
+| `manifest-lint-agent` | Repair schema, naming, ordering, and convention issues reported by tooling. | `shared/*.control.meta`, `editions/*/manifests/*.control.meta` | May apply mechanical fixes that are directly implied by validation output. | `python tools/validate_manifests.py`, `pytest tests/test_validation.py tests/test_control_meta_conventions.py` |
+| `modlist-regenerator` | Regenerate derived modlist markdown after manifest edits. | `editions/*/MODLIST.md`, manifest files when needed for context | Generated output only; do not hand-edit generated sections. | `python tools/generate_modlist_markdown.py`, `python tools/validate_manifests.py` |
+| `edition-drift-auditor` | Identify unintended divergence between OpenMW and MWSE editions. | `editions/openmw/**`, `editions/mwse/**`, `tools/compare_editions.py` | Report or annotate; do not force parity when divergence is intentional. | `python tools/compare_editions.py`, `python tools/check_duplicate_mods.py` |
+| `documentation-sync-agent` | Keep README, roadmap, checklist, and policy references synchronized. | `README.md`, `ROADMAP.md`, `FOLLOW-UP-TASKS.md`, `editions/*/docs/*.md` | May edit prose and links; must not change project scope without explicit request. | `pytest` when tooling docs change; otherwise markdown review only. |
+| `release-readiness-agent` | Prepare Wabbajack release checklist status summaries. | `editions/*/wabbajack/*.md`, `editions/*/docs/*.md`, manifests | Checklist and gap reporting only until human release review. | `python tools/validate_manifests.py`, `python tools/generate_modlist_markdown.py`, `pytest` |
+
+## Preset definitions
+
+### `source-triage-agent`
+
+Use this preset for sourcing backlog cleanup and provenance review.
+
+**Inputs**
+- Open blockers in `shared/source-triage.control.meta`.
+- Candidate records in `shared/sourced-mods.control.meta`.
+- Multi-package source details in `shared/source-package-meta.control.meta`.
+
+**Allowed actions**
+- Add evidence notes from verified, cited sources.
+- Normalize candidate IDs, source confidence labels, thematic buckets, and promotion targets when the evidence is already present.
+- Cross-reference multi-package sources without changing acceptance status.
+
+**Stop conditions**
+- The agent cannot verify a source identity.
+- A source has unclear redistribution or package constraints.
+- A candidate would need human compatibility judgment.
+
+**Completion report**
+- List each candidate touched.
+- Separate verified facts from unresolved assumptions.
+- State why any blocked item remains blocked.
+
+### `manifest-lint-agent`
+
+Use this preset when validation fails or metadata conventions drift.
+
+**Inputs**
+- Tool output from `python tools/validate_manifests.py`.
+- Relevant tests under `tests/`.
+- Manifest schema guidance in `shared/mod-meta-schema.md` and naming rules in `shared/naming-policy.md`.
+
+**Allowed actions**
+- Fix YAML structure, missing required fields, duplicate IDs, filename convention issues, and sort/order issues when the intended value is unambiguous.
+- Add placeholder-safe values only when existing policy explicitly permits them.
+
+**Stop conditions**
+- A fix requires inventing source metadata, compatibility status, or review evidence.
+- Validation output points to a design decision rather than a structural issue.
+
+**Completion report**
+- Quote the failing validation category in summary form.
+- List mechanical fixes applied.
+- Include before/after check results.
+
+### `modlist-regenerator`
+
+Use this preset after manifest changes that affect public modlist markdown.
+
+**Inputs**
+- Current manifests under `editions/*/manifests/`.
+- Generator implementation in `tools/generate_modlist_markdown.py`.
+
+**Allowed actions**
+- Run the generator.
+- Commit regenerated markdown when it is the expected result of manifest changes.
+
+**Stop conditions**
+- Generated output includes unexpected deletions or scope changes.
+- The generator fails or emits content that contradicts manifest status.
+
+**Completion report**
+- Identify generated files changed.
+- State whether changes are purely generated or accompanied by manifest edits.
+
+### `edition-drift-auditor`
+
+Use this preset to check whether Pilgrim and Sleeper diverged intentionally.
+
+**Inputs**
+- `tools/compare_editions.py` output.
+- Edition README files and load-order policies.
+- Shared design rules and the project bible.
+
+**Allowed actions**
+- Open issues or add notes for unexplained drift.
+- Flag duplicate candidates, mismatched status, or cross-edition notes that lack rationale.
+
+**Stop conditions**
+- The correct fix would require deciding feature parity.
+- Differences are clearly engine-specific or lore/design-specific.
+
+**Completion report**
+- Classify drift as `intentional`, `needs-review`, or `mechanical-fix-applied`.
+- Preserve edition-specific rationale.
+
+### `documentation-sync-agent`
+
+Use this preset for keeping planning documents consistent.
+
+**Inputs**
+- Root README and contributing docs.
+- `ROADMAP.md`, `FOLLOW-UP-TASKS.md`, `PROJECT-BIBLE.md`.
+- Edition documentation under `editions/*/docs/`.
+
+**Allowed actions**
+- Update links, command lists, status references, and checklist wording.
+- Add planning documents for new maintenance workflows.
+
+**Stop conditions**
+- A change would alter design pillars, edition identity, roadmap phase gates, or release claims.
+
+**Completion report**
+- List changed docs and the consistency issue each change resolves.
+- Confirm no installability, compatibility, or release-readiness claim was added unless already evidenced.
+
+### `release-readiness-agent`
+
+Use this preset only for pre-release evidence gathering and checklist preparation.
+
+**Inputs**
+- Edition release checklists.
+- Install, post-install, known-issues, and testing docs.
+- Current validation and generation output.
+
+**Allowed actions**
+- Mark checklist items as blocked, pending, or evidence-needed.
+- Prepare release-gap summaries.
+- Confirm that required commands still pass.
+
+**Stop conditions**
+- Any checklist item requires a completed end-to-end install test not present in repository evidence.
+- Any release note would imply an installable build before Phase 4 criteria are met.
+
+**Completion report**
+- Summarize readiness by edition.
+- List blockers by severity.
+- Include exact validation commands and results.
+
+## Recommended local preset format
+
+Local agent runners can encode each preset as YAML, JSON, or TOML. Keep the structure simple and auditable:
+
+```yaml
+name: source-triage-agent
+scope:
+  - ash-archive/shared/source-triage.control.meta
+  - ash-archive/shared/sourced-mods.control.meta
+mode: evidence-first
+allowed_actions:
+  - annotate_verified_sources
+  - normalize_existing_metadata
+forbidden_actions:
+  - invent_provenance
+  - promote_candidates_without_review
+required_checks:
+  - python tools/validate_manifests.py
+  - pytest tests/test_sourced_mods.py
+handoff:
+  require_summary: true
+  require_uncertainty_log: true
+```
+
+Preset files should live outside generated content. If committed later, prefer a dedicated configuration directory such as `.agents/presets/` with one preset per file and a README that points back to this plan.
+
+## Automation rollout plan
+
+1. **Document-first pass** - keep this plan as the canonical description of safe agent behavior.
+2. **Dry-run prompts** - test each preset against a copied branch and require read-only summaries before allowing edits.
+3. **Mechanical-edit enablement** - allow `manifest-lint-agent` and `modlist-regenerator` to write changes after their checks are stable.
+4. **Evidence workflows** - allow `source-triage-agent` to annotate records only when citations and uncertainty logs are included.
+5. **Release workflows** - keep `release-readiness-agent` advisory-only until Phase 4 release preparation.
+
+## Human review gates
+
+Human review remains required for:
+
+- Accepting or rejecting mods.
+- Promoting candidates into edition manifests.
+- Compatibility claims based on playtesting.
+- Wabbajack release readiness.
+- Any change that weakens the project bible, evidence standards, or edition distinction.

--- a/ash-archive/tests/test_meta_filename_conventions.py
+++ b/ash-archive/tests/test_meta_filename_conventions.py
@@ -3,40 +3,40 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 
-SHARED_META_FILES = [
-    "shared/categories.meta",
-    "shared/sourced-mods.meta",
-    "shared/source-triage.meta",
-    "shared/source-package-meta.meta",
+CONTROL_META_FILES = [
+    "shared/categories.control.meta",
+    "shared/sourced-mods.control.meta",
+    "shared/source-triage.control.meta",
+    "shared/source-package-meta.control.meta",
 ]
 
 
 def _to_legacy_yaml_path(meta_path: Path) -> Path:
-    return meta_path.with_suffix(".yaml")
+    return meta_path.with_name(meta_path.name.replace(".control.meta", ".yaml"))
 
 
 def test_expected_meta_files_exist() -> None:
     edition_manifest_meta = sorted(
-        ROOT.glob("editions/*/manifests/*.meta"),
+        ROOT.glob("editions/*/manifests/*.control.meta"),
     )
     fixture_meta = sorted(
-        ROOT.glob("tests/fixtures/*.meta"),
+        ROOT.glob("tests/fixtures/*.control.meta"),
     )
 
-    assert edition_manifest_meta, "expected .meta files under editions/*/manifests/"
-    assert fixture_meta, "expected .meta fixtures under tests/fixtures/"
+    assert edition_manifest_meta, "expected .control.meta files under editions/*/manifests/"
+    assert fixture_meta, "expected .control.meta fixtures under tests/fixtures/"
 
-    for rel_path in SHARED_META_FILES:
+    for rel_path in CONTROL_META_FILES:
         meta_path = ROOT / rel_path
-        assert meta_path.exists(), f"missing shared metadata file: {rel_path}"
+        assert meta_path.exists(), f"missing shared control metadata file: {rel_path}"
 
 
 def test_legacy_yaml_equivalents_absent() -> None:
-    canonical_meta_paths = [ROOT / rel_path for rel_path in SHARED_META_FILES]
-    canonical_meta_paths.extend(ROOT.glob("editions/*/manifests/*.meta"))
-    canonical_meta_paths.extend(ROOT.glob("tests/fixtures/*.meta"))
+    canonical_meta_paths = [ROOT / rel_path for rel_path in CONTROL_META_FILES]
+    canonical_meta_paths.extend(ROOT.glob("editions/*/manifests/*.control.meta"))
+    canonical_meta_paths.extend(ROOT.glob("tests/fixtures/*.control.meta"))
 
-    assert canonical_meta_paths, "no canonical .meta files discovered"
+    assert canonical_meta_paths, "no canonical .control.meta files discovered"
 
     for meta_path in canonical_meta_paths:
         yaml_path = _to_legacy_yaml_path(meta_path)


### PR DESCRIPTION
### Motivation

- Standardize safe, conservative local agent behaviour for recurring maintenance tasks and prevent automated synthesis of provenance or compatibility claims.
- Surface the planned presets and guardrails in project documentation so contributors reference the canonical automation policy.
- Ensure repository tests reflect the current `.control.meta` naming convention to avoid spurious failures.

### Description

- Add `ash-archive/LOCAL-AGENT-PRESETS.md` which defines shared operating rules, a preset matrix (including `source-triage-agent`, `manifest-lint-agent`, `modlist-regenerator`, `edition-drift-auditor`, `documentation-sync-agent`, and `release-readiness-agent`), detailed preset responsibilities, example config shape, rollout plan, and human review gates.
- Update `README.md` to link the new `LOCAL-AGENT-PRESETS.md` from the documentation index.
- Update `AGENT-RULES.md` to reference `ash-archive/LOCAL-AGENT-PRESETS.md` in the required agent workflow.
- Adjust `ash-archive/tests/test_meta_filename_conventions.py` to assert the repository's `.control.meta` filenames and to correctly detect legacy YAML equivalents.

### Testing

- Ran `cd ash-archive && python tools/validate_manifests.py` which reported validation passed for `openmw` and `mwse`.
- Ran `cd ash-archive && pytest` which initially surfaced a filename-convention failure and after updating the test file all automated tests completed successfully as `28 passed`.
- Confirmed the validation and test commands mentioned above were executed and returned OK results for the modified tree.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4d594c693c8333ba2f7072b6ec60ba)