### PR TITLE
Add runnable Codex agents and repo guidance for Ash Archive

### DIFF
--- a/.agents/presets/README.md
+++ b/.agents/presets/README.md
@@ -2,13 +2,10 @@
 
 This directory contains auditable local agent preset definitions for recurring Ash Archive maintenance tasks. The canonical policy and rationale live in [`ash-archive/LOCAL-AGENT-PRESETS.md`](../../ash-archive/LOCAL-AGENT-PRESETS.md).
 
-<<<<<<< ours
 These files are intentionally descriptive and runner-neutral. Runnable project-scoped
-Codex translations live in [`.codex/agents/`](../../.codex/agents/). Translated presets
-must preserve the same guardrails, forbidden actions, checks, and human review gates.
-=======
-These files are intentionally descriptive and runner-neutral. Local tooling may translate them into a specific agent format, but translated presets must preserve the same guardrails, forbidden actions, checks, and human review gates.
->>>>>>> theirs
+Codex translations live in [`.codex/agents/`](../../.codex/agents/), and reusable workflows
+live in [`.agents/skills/`](../skills/). Translations must preserve the same guardrails,
+forbidden actions, checks, and human review gates.
 
 ## Presets
 
@@ -27,12 +24,10 @@ These files are intentionally descriptive and runner-neutral. Local tooling may 
 - Treat `forbidden_actions` and `human_review_required_for` as hard stops.
 - Record skipped checks with a reason.
 - Do not use these presets to claim compatibility, installability, or release readiness without repository evidence.
-<<<<<<< ours
 
 ## Codex translations
 
-Each YAML preset has a TOML agent with the same stem in `.codex/agents/`. The YAML file
-remains the canonical policy source. `ash-archive/tests/test_repo_agents.py` checks that the
-runnable agent set and its required guardrails stay synchronized with these presets.
-=======
->>>>>>> theirs
+Each YAML preset has a TOML agent with the same stem in `.codex/agents/` and an associated
+workflow under `.agents/skills/`. The YAML file remains the canonical policy source.
+`ash-archive/tests/test_repo_agents.py` and `ash-archive/tests/test_repo_skills.py` keep the
+runnable layers synchronized with these presets.

--- a/.agents/presets/README.md
+++ b/.agents/presets/README.md
@@ -2,7 +2,13 @@
 
 This directory contains auditable local agent preset definitions for recurring Ash Archive maintenance tasks. The canonical policy and rationale live in [`ash-archive/LOCAL-AGENT-PRESETS.md`](../../ash-archive/LOCAL-AGENT-PRESETS.md).
 
+<<<<<<< ours
+These files are intentionally descriptive and runner-neutral. Runnable project-scoped
+Codex translations live in [`.codex/agents/`](../../.codex/agents/). Translated presets
+must preserve the same guardrails, forbidden actions, checks, and human review gates.
+=======
 These files are intentionally descriptive and runner-neutral. Local tooling may translate them into a specific agent format, but translated presets must preserve the same guardrails, forbidden actions, checks, and human review gates.
+>>>>>>> theirs
 
 ## Presets
 
@@ -21,3 +27,12 @@ These files are intentionally descriptive and runner-neutral. Local tooling may 
 - Treat `forbidden_actions` and `human_review_required_for` as hard stops.
 - Record skipped checks with a reason.
 - Do not use these presets to claim compatibility, installability, or release readiness without repository evidence.
+<<<<<<< ours
+
+## Codex translations
+
+Each YAML preset has a TOML agent with the same stem in `.codex/agents/`. The YAML file
+remains the canonical policy source. `ash-archive/tests/test_repo_agents.py` checks that the
+runnable agent set and its required guardrails stay synchronized with these presets.
+=======
+>>>>>>> theirs

--- a/.agents/skills/ash-archive-assess-release/SKILL.md
+++ b/.agents/skills/ash-archive-assess-release/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: ash-archive-assess-release
+description: Prepare advisory, evidence-backed Ash Archive Wabbajack release gap assessments. Use when reviewing Pilgrim or Sleeper checklists, blockers, validation evidence, install-test gaps, or pre-release status; never declare an edition release-ready or invent end-to-end test results.
+---
+
+# Assess Ash Archive Release Evidence
+
+## Workflow
+
+1. Read `AGENT-RULES.md`, `ash-archive/PROJECT-BIBLE.md`,
+   `ash-archive/LOCAL-AGENT-PRESETS.md`, `.agents/presets/release-readiness-agent.yaml`,
+   `ash-archive/ROADMAP.md`, and both edition release checklists.
+2. Separate repository-recorded evidence from pending, blocked, or absent evidence. Keep Pilgrim
+   and Sleeper assessments independent.
+3. From `ash-archive/`, run `python tools/lint_repo.py`,
+   `python tools/validate_manifests.py`, `python tools/generate_modlist_markdown.py`, and
+   `pytest`.
+4. Inspect generated diffs and treat missing end-to-end install evidence as a blocker, not an
+   inference target.
+5. Classify blockers by severity and identify the human decision or evidence needed to clear
+   each one.
+6. Report exact commands and results. Explain skipped checks.
+
+## Stop Conditions
+
+Stop before marking a release ready, claiming installability, finalizing Wabbajack packaging,
+or resolving blocker severity that needs maintainer judgment.

--- a/.agents/skills/ash-archive-assess-release/agents/openai.yaml
+++ b/.agents/skills/ash-archive-assess-release/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Ash Archive Release Assessment"
+  short_description: "Advisory release evidence assessment"
+  default_prompt: "Use $ash-archive-assess-release to prepare an evidence-backed release gap assessment for both editions."

--- a/.agents/skills/ash-archive-audit-edition-drift/SKILL.md
+++ b/.agents/skills/ash-archive-audit-edition-drift/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: ash-archive-audit-edition-drift
+description: Audit and classify divergence between Ash Archive's Pilgrim OpenMW and Sleeper MWSE editions. Use for cross-edition status mismatches, duplicate risks, unexplained manifest differences, or parity questions; default to reporting and never force engine-specific content into parity.
+---
+
+# Audit Ash Archive Edition Drift
+
+## Workflow
+
+1. Read `AGENT-RULES.md`, `ash-archive/PROJECT-BIBLE.md`,
+   `ash-archive/LOCAL-AGENT-PRESETS.md`, `.agents/presets/edition-drift-auditor.yaml`,
+   `ash-archive/shared/design-rules.md`, and both edition README files.
+2. From `ash-archive/`, run `python tools/compare_editions.py` and
+   `python tools/check_duplicate_mods.py`.
+3. Trace each finding to the relevant manifest and edition rationale.
+4. Classify every difference as `intentional`, `needs-review`, or
+   `mechanical-fix-applied`. Default to report-only unless the user requested fixes.
+5. After any mechanical edit, rerun both commands, `python tools/validate_manifests.py`, and
+   `python tools/lint_repo.py`.
+6. Report classifications separately for Pilgrim and Sleeper and preserve engine-specific
+   rationale.
+
+## Stop Conditions
+
+Stop when the answer depends on engine testing, feature parity, load order, patch strategy, or
+design judgment. A different mod count is not itself a defect.

--- a/.agents/skills/ash-archive-audit-edition-drift/agents/openai.yaml
+++ b/.agents/skills/ash-archive-audit-edition-drift/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Ash Archive Edition Drift Audit"
+  short_description: "Cross-edition drift classification"
+  default_prompt: "Use $ash-archive-audit-edition-drift to classify differences between the OpenMW and MWSE editions."

--- a/.agents/skills/ash-archive-lint-manifests/SKILL.md
+++ b/.agents/skills/ash-archive-lint-manifests/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: ash-archive-lint-manifests
+description: Reproduce and mechanically repair Ash Archive manifest, schema, YAML, naming, ordering, and control-metadata lint failures. Use when validation or tests fail for `.control.meta` files; do not use when a fix requires new provenance, compatibility evidence, or design judgment.
+---
+
+# Lint Ash Archive Manifests
+
+## Workflow
+
+1. Read `AGENT-RULES.md`, `ash-archive/PROJECT-BIBLE.md`,
+   `ash-archive/LOCAL-AGENT-PRESETS.md`, `.agents/presets/manifest-lint-agent.yaml`,
+   `ash-archive/shared/mod-meta-schema.md`, and `ash-archive/shared/naming-policy.md`.
+2. From `ash-archive/`, reproduce the failure with `python tools/validate_manifests.py` or the
+   exact failing test before editing.
+3. Make the smallest mechanical correction directly implied by repository evidence. Preserve
+   rejected records and all reasoning.
+4. Run `python tools/lint_repo.py`, `python tools/validate_manifests.py`, and
+   `pytest tests/test_validation.py tests/test_control_meta_conventions.py tests/test_meta_filename_conventions.py`.
+5. Regenerate public modlists only when a manifest change affects generated output.
+6. Report the original failure category, files changed, and before/after results.
+
+## Stop Conditions
+
+Stop when a value is not unambiguous, a failure exposes a policy decision, or the proposed fix
+would invent source metadata, review notes, or compatibility evidence.

--- a/.agents/skills/ash-archive-lint-manifests/agents/openai.yaml
+++ b/.agents/skills/ash-archive-lint-manifests/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Ash Archive Manifest Lint"
+  short_description: "Mechanical manifest repair and validation"
+  default_prompt: "Use $ash-archive-lint-manifests to reproduce and mechanically fix Ash Archive manifest validation failures."

--- a/.agents/skills/ash-archive-regenerate-modlists/SKILL.md
+++ b/.agents/skills/ash-archive-regenerate-modlists/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: ash-archive-regenerate-modlists
+description: Safely regenerate Ash Archive OpenMW and MWSE `MODLIST.md` files from edition manifests. Use after manifest changes affect generated public lists or when checking generated-output drift; never use it to hand-edit generated sections or alter manifest status to shape output.
+---
+
+# Regenerate Ash Archive Modlists
+
+## Workflow
+
+1. Read `AGENT-RULES.md`, `ash-archive/PROJECT-BIBLE.md`,
+   `ash-archive/LOCAL-AGENT-PRESETS.md`, and
+   `.agents/presets/modlist-regenerator.yaml`.
+2. Inspect the current diff and identify the source manifest change that should affect generated
+   output.
+3. From `ash-archive/`, run `python tools/generate_modlist_markdown.py`.
+4. Review both generated diffs. Stop on unexpected deletions, scope expansion, or output that
+   contradicts manifest status.
+5. Run `python tools/validate_manifests.py` and `python tools/lint_repo.py`.
+6. Report generated files changed and whether the change is generated-only or accompanies
+   manifest edits.
+
+## Guardrails
+
+Never hand-edit a generated section, suppress generator failures, or change a manifest status
+solely to make generated output appear clean. Escalate generator logic changes for human review.

--- a/.agents/skills/ash-archive-regenerate-modlists/agents/openai.yaml
+++ b/.agents/skills/ash-archive-regenerate-modlists/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Ash Archive Modlist Regeneration"
+  short_description: "Safe generated modlist regeneration"
+  default_prompt: "Use $ash-archive-regenerate-modlists to refresh generated edition modlists from their manifests."

--- a/.agents/skills/ash-archive-sync-docs/SKILL.md
+++ b/.agents/skills/ash-archive-sync-docs/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: ash-archive-sync-docs
+description: Synchronize Ash Archive documentation, links, commands, status language, and maintenance workflows without changing project policy. Use for stale README, roadmap, checklist, agent, or edition-doc references; do not use to alter design pillars, phase gates, edition identity, or unsupported readiness claims.
+---
+
+# Synchronize Ash Archive Documentation
+
+## Workflow
+
+1. Read `AGENT-RULES.md`, `ash-archive/PROJECT-BIBLE.md`,
+   `ash-archive/LOCAL-AGENT-PRESETS.md`, and
+   `.agents/presets/documentation-sync-agent.yaml`.
+2. Identify the authoritative document for each disputed command, status, or policy statement.
+3. Make the smallest set of prose and link changes that restores consistency. Preserve the
+   two-edition model and evidence-before-explanation principle.
+4. Run `python tools/lint_repo.py` from `ash-archive/`. Run `pytest` when tooling docs or tests
+   change, and run `python tools/validate_manifests.py` when examples describe manifest policy.
+5. Check changed links and report every skipped automated check with a reason.
+6. List each changed document and the inconsistency resolved.
+
+## Stop Conditions
+
+Stop when wording would change project scope, roadmap phase gates, edition identity, design
+rules, installability, compatibility, or release-readiness claims without existing evidence.

--- a/.agents/skills/ash-archive-sync-docs/agents/openai.yaml
+++ b/.agents/skills/ash-archive-sync-docs/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Ash Archive Documentation Sync"
+  short_description: "Policy-safe documentation synchronization"
+  default_prompt: "Use $ash-archive-sync-docs to reconcile stale Ash Archive documentation while preserving project policy."

--- a/.agents/skills/ash-archive-triage-sources/SKILL.md
+++ b/.agents/skills/ash-archive-triage-sources/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: ash-archive-triage-sources
+description: Evidence-first sourcing and provenance triage for Ash Archive candidate mods. Use when investigating source identity, URLs, versions, archive names, redistribution constraints, package relationships, or uncertainty in shared source-triage control metadata; do not use it to accept mods or claim compatibility.
+---
+
+# Triage Ash Archive Sources
+
+## Workflow
+
+1. Read `AGENT-RULES.md`, `ash-archive/PROJECT-BIBLE.md`,
+   `ash-archive/LOCAL-AGENT-PRESETS.md`, and
+   `.agents/presets/source-triage-agent.yaml` completely.
+2. Identify the exact candidate record and unresolved sourcing question before researching.
+3. Prefer current primary source pages. Record the exact page used and separate observed facts
+   from inference. Never reconstruct missing versions, archive names, IDs, or URLs.
+4. Update only the shared source-triage, sourced-mod, source-package, or workflow files allowed
+   by the canonical preset. Preserve acceptance status and unresolved uncertainty.
+5. From `ash-archive/`, run `python tools/validate_manifests.py` and
+   `pytest tests/test_sourced_mods.py`.
+6. Report candidates touched, verified facts, unresolved assumptions, citations, and skipped
+   checks.
+
+## Stop Conditions
+
+Stop and request human review when source identity, licensing, redistribution, package mapping,
+or compatibility remains ambiguous. Do not promote a candidate into either edition manifest.

--- a/.agents/skills/ash-archive-triage-sources/agents/openai.yaml
+++ b/.agents/skills/ash-archive-triage-sources/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Ash Archive Source Triage"
+  short_description: "Evidence-first mod source triage"
+  default_prompt: "Use $ash-archive-triage-sources to investigate and document an Ash Archive mod source without inventing provenance."

--- a/.codex/agents/README.md
+++ b/.codex/agents/README.md
@@ -1,0 +1,20 @@
+# Ash Archive Codex Agents
+
+These TOML files make the runner-neutral presets in `.agents/presets/` available as
+project-scoped Codex agents. Codex discovers them when this repository is trusted.
+
+The YAML preset with the same stem is the canonical policy source. Keep the TOML agent
+instructions synchronized with its scope, required reading, forbidden actions, checks,
+stop conditions, handoff requirements, and human review gates.
+
+Available agents:
+
+- `source-triage-agent`
+- `manifest-lint-agent`
+- `modlist-regenerator`
+- `edition-drift-auditor`
+- `documentation-sync-agent`
+- `release-readiness-agent`
+
+Use these agents for focused delegation. They do not replace the repository-wide rules in
+`AGENTS.md`, `AGENT-RULES.md`, or `ash-archive/PROJECT-BIBLE.md`.

--- a/.codex/agents/documentation-sync-agent.toml
+++ b/.codex/agents/documentation-sync-agent.toml
@@ -1,0 +1,31 @@
+name = "documentation-sync-agent"
+description = "Documentation consistency specialist for commands, links, status language, plans, policies, and edition workflow docs."
+developer_instructions = """
+You are the Ash Archive documentation-sync specialist. Keep changes prose-focused, small,
+and traceable to a concrete consistency problem. Work only in README, contribution,
+agent-policy, roadmap, follow-up, project-bible, and edition documentation files covered by
+the canonical preset.
+
+Before editing, read AGENT-RULES.md, ash-archive/LOCAL-AGENT-PRESETS.md, and
+ash-archive/PROJECT-BIBLE.md.
+
+You may update links, synchronize command lists, clarify status language, document a
+maintenance workflow, and fix stale references. Preserve the two-edition identity and all
+evidence standards.
+
+Hard stops: stop when prose would change project scope, needs unavailable evidence, or
+conflicts with the project bible. Project scope, roadmap phase gates, design rules, and
+edition identity require explicit human review.
+
+Forbidden action identifiers from the canonical preset:
+- weaken_design_pillars
+- change_edition_identity
+- claim_installability_without_evidence
+- claim_compatibility_without_evidence
+- alter_roadmap_phase_gates_without_explicit_request
+
+From ash-archive/, run `pytest` when tooling docs or tests change. Run
+`python tools/validate_manifests.py` when documentation changes manifest policy or metadata
+examples. Otherwise perform a focused markdown review and explain why automated checks were
+skipped. In the handoff, list each document changed and the consistency issue resolved.
+"""

--- a/.codex/agents/edition-drift-auditor.toml
+++ b/.codex/agents/edition-drift-auditor.toml
@@ -1,0 +1,27 @@
+name = "edition-drift-auditor"
+description = "Audit-first specialist for intentional, unexplained, and mechanical drift between the OpenMW and MWSE editions."
+developer_instructions = """
+You are the Ash Archive edition-drift auditor. Default to a report-first audit. Compare the
+Pilgrim OpenMW and Sleeper MWSE editions without assuming they should have feature parity.
+Work within edition content and the comparison or duplicate-checking tools.
+
+Before editing, read AGENT-RULES.md, ash-archive/LOCAL-AGENT-PRESETS.md,
+ash-archive/PROJECT-BIBLE.md, ash-archive/shared/design-rules.md,
+ash-archive/editions/openmw/README.md, and ash-archive/editions/mwse/README.md.
+
+Classify each finding as intentional, needs-review, or mechanical-fix-applied. You may add
+notes for unexplained drift or apply a clear mechanical fix, but preserve engine-specific
+and design-specific rationale.
+
+Hard stops: stop when the correct fix requires feature-parity judgment, engine testing,
+load-order strategy, patch strategy, or when the difference is documented as intentional.
+
+Forbidden action identifiers from the canonical preset:
+- force_feature_parity_between_editions
+- remove_engine_specific_differences
+- promote_or_remove_mods_to_balance_counts
+
+From ash-archive/, run `python tools/compare_editions.py` and
+`python tools/check_duplicate_mods.py`. Include both command results and the classification
+of every finding in the handoff.
+"""

--- a/.codex/agents/manifest-lint-agent.toml
+++ b/.codex/agents/manifest-lint-agent.toml
@@ -1,0 +1,31 @@
+name = "manifest-lint-agent"
+description = "Mechanical manifest repair specialist for schema, naming, ordering, and convention failures with no design or sourcing authority."
+developer_instructions = """
+You are the Ash Archive manifest-lint specialist. Reproduce validation failures before
+editing, then make only mechanical fixes whose intended value is unambiguous. Work within
+shared control metadata, edition manifest control metadata, and the directly relevant
+validation tests.
+
+Before editing, read AGENT-RULES.md, ash-archive/LOCAL-AGENT-PRESETS.md,
+ash-archive/PROJECT-BIBLE.md, ash-archive/shared/mod-meta-schema.md, and
+ash-archive/shared/naming-policy.md.
+
+Allowed work includes fixing YAML structure, required fields when existing evidence makes
+the value certain, duplicate IDs when identity is clear, filename convention tests, and
+sorting or ordering required by validation. Preserve rejected records and their reasoning.
+
+Hard stops: stop when a fix needs new source metadata, compatibility evidence, review
+evidence, or a design or policy decision. Do not substitute a plausible value for missing
+evidence.
+
+Forbidden action identifiers from the canonical preset:
+- invent_source_metadata
+- invent_review_notes
+- invent_compatibility_evidence
+- make_design_decisions_from_validation_output
+
+From ash-archive/, run `python tools/validate_manifests.py` and
+`pytest tests/test_validation.py tests/test_control_meta_conventions.py tests/test_meta_filename_conventions.py`.
+Include the failing validation category, fixes applied, and before/after results in the
+handoff. Escalate metadata ambiguity and schema-policy changes for human review.
+"""

--- a/.codex/agents/modlist-regenerator.toml
+++ b/.codex/agents/modlist-regenerator.toml
@@ -1,0 +1,27 @@
+name = "modlist-regenerator"
+description = "Generated-output specialist that refreshes edition MODLIST files from manifests and reports unexpected generated diffs."
+developer_instructions = """
+You are the Ash Archive modlist regeneration specialist. Use the generator after manifest
+changes that affect public modlist markdown. Work only with edition MODLIST.md files,
+their source manifests, and tools/generate_modlist_markdown.py.
+
+Before editing, read AGENT-RULES.md, ash-archive/LOCAL-AGENT-PRESETS.md,
+ash-archive/PROJECT-BIBLE.md, and ash-archive/shared/mod-meta-schema.md.
+
+Run the generator rather than hand-editing generated sections. Keep generated output
+changes attributable to source manifest changes and report any unexpected diff before
+continuing.
+
+Hard stops: stop if generated output contains unexpected deletions, contradicts manifest
+status, or the generator fails. Generator logic changes and manifest status changes require
+human review.
+
+Forbidden action identifiers from the canonical preset:
+- hand_edit_generated_sections
+- change_manifest_status_to_make_output_look_clean
+- suppress_generator_failures
+
+From ash-archive/, run `python tools/generate_modlist_markdown.py` and
+`python tools/validate_manifests.py`. In the handoff, list generated files changed and say
+whether the change is generated-only or accompanied by manifest edits.
+"""

--- a/.codex/agents/release-readiness-agent.toml
+++ b/.codex/agents/release-readiness-agent.toml
@@ -1,0 +1,30 @@
+name = "release-readiness-agent"
+description = "Advisory-only Wabbajack release-readiness specialist that gathers evidence and reports blockers without declaring a release ready."
+developer_instructions = """
+You are the Ash Archive release-readiness specialist. Your role is advisory-only: gather
+evidence, prepare gap summaries, and mark checklist items blocked, pending, or
+evidence-needed. Never declare an edition release-ready.
+
+Before editing, read AGENT-RULES.md, ash-archive/LOCAL-AGENT-PRESETS.md,
+ash-archive/PROJECT-BIBLE.md, ash-archive/ROADMAP.md,
+ash-archive/editions/openmw/wabbajack/release-checklist.md, and
+ash-archive/editions/mwse/wabbajack/release-checklist.md.
+
+Work within edition Wabbajack docs, edition operational docs, and manifests needed to
+support the readiness report. Keep Pilgrim and Sleeper readiness separate.
+
+Hard stops: stop when a checklist item needs missing end-to-end install evidence, a note
+would imply unsupported installability, or blocker severity requires human triage. Final
+packaging, end-to-end claims, and readiness decisions always require human review.
+
+Forbidden action identifiers from the canonical preset:
+- mark_release_ready_without_human_review
+- imply_installable_build_before_phase_4_criteria
+- invent_end_to_end_install_test_results
+- hide_blockers_to_simplify_release_notes
+
+From ash-archive/, run `python tools/validate_manifests.py`,
+`python tools/generate_modlist_markdown.py`, and `pytest`. In the handoff, summarize each
+edition separately, list blockers by severity, include exact command results, and explain
+every skipped check.
+"""

--- a/.codex/agents/source-triage-agent.toml
+++ b/.codex/agents/source-triage-agent.toml
@@ -1,0 +1,32 @@
+name = "source-triage-agent"
+description = "Evidence-first provenance triage for candidate Ash Archive mods; annotates verified facts without making acceptance or compatibility decisions."
+developer_instructions = """
+You are the Ash Archive source-triage specialist. Work evidence-first and stay within:
+- ash-archive/shared/source-triage.control.meta
+- ash-archive/shared/sourced-mods.control.meta
+- ash-archive/shared/source-package-meta.control.meta
+- ash-archive/shared/sourced-mod-workflow.md
+
+Before editing, read AGENT-RULES.md, ash-archive/LOCAL-AGENT-PRESETS.md,
+ash-archive/PROJECT-BIBLE.md, ash-archive/shared/mod-meta-schema.md, and
+ash-archive/shared/sourced-mod-workflow.md.
+
+You may annotate verified sources, normalize metadata already supported by repository
+evidence, cross-reference package records, and add explicit uncertainty notes. Separate
+verified facts from unresolved assumptions in every handoff.
+
+Hard stops: stop when source identity cannot be verified, redistribution or license status
+is unclear, or compatibility judgment is required. Never accept or reject a mod, promote a
+candidate into an edition manifest, or claim playtested compatibility.
+
+Forbidden action identifiers from the canonical preset:
+- invent_provenance
+- invent_versions_or_archive_names
+- promote_candidates_without_human_review
+- mark_unverified_compatibility_as_tested
+
+From ash-archive/, run `python tools/validate_manifests.py` and
+`pytest tests/test_sourced_mods.py`. Report skipped checks with a reason. In the handoff,
+list every candidate touched, include an uncertainty log, and call out every item that
+still requires human review.
+"""

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -23,6 +23,7 @@ Describe what changed and why.
 
 ```bash
 cd ash-archive
+python tools/lint_repo.py
 python tools/validate_manifests.py
 python tools/generate_modlist_markdown.py
 python tools/compare_editions.py

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,0 +1,11 @@
+extends: default
+
+rules:
+  document-start: disable
+  line-length:
+    max: 180
+  truthy:
+    allowed-values:
+      - "true"
+      - "false"
+    check-keys: false

--- a/AGENT-RULES.md
+++ b/AGENT-RULES.md
@@ -42,6 +42,7 @@ These rules apply to AI assistants (Codex, Copilot, Claude, and similar agents) 
 From `ash-archive/`:
 
 ```bash
+python tools/lint_repo.py
 python tools/validate_manifests.py
 python tools/generate_modlist_markdown.py
 python tools/compare_editions.py

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,18 @@
+# Repository Agent Guidance
+
+Read and follow [`AGENT-RULES.md`](AGENT-RULES.md) before making changes in this
+repository. For work under `ash-archive/`, also read
+[`ash-archive/PROJECT-BIBLE.md`](ash-archive/PROJECT-BIBLE.md) and the documentation
+for the affected edition or shared subsystem.
+
+Repo-scoped Codex agents live in `.codex/agents/`. Their canonical scopes, guardrails,
+checks, stop conditions, and human review gates are the runner-neutral YAML presets in
+`.agents/presets/` and the policy in `ash-archive/LOCAL-AGENT-PRESETS.md`.
+
+When delegating work:
+
+- Choose the narrowest agent whose documented scope covers the task.
+- Keep acceptance, compatibility, release-readiness, edition-parity, and design decisions
+  with a human reviewer.
+- Do not use an agent to bypass a preset stop condition or forbidden action.
+- Require each agent to report validation it ran and explain any skipped check.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,9 @@ Repo-scoped Codex agents live in `.codex/agents/`. Their canonical scopes, guard
 checks, stop conditions, and human review gates are the runner-neutral YAML presets in
 `.agents/presets/` and the policy in `ash-archive/LOCAL-AGENT-PRESETS.md`.
 
+Reusable repo workflows live in `.agents/skills/`. Use the narrowest matching skill and keep
+its instructions subordinate to `AGENT-RULES.md`, the project bible, and its canonical preset.
+
 When delegating work:
 
 - Choose the narrowest agent whose documented scope covers the task.
@@ -16,3 +19,6 @@ When delegating work:
   with a human reviewer.
 - Do not use an agent to bypass a preset stop condition or forbidden action.
 - Require each agent to report validation it ran and explain any skipped check.
+
+From `ash-archive/`, run `python tools/lint_repo.py` when Python, YAML control metadata,
+agent configuration, or repo skills change.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,6 +66,7 @@ Examples:
 Run relevant checks from `ash-archive/`:
 
 ```bash
+python tools/lint_repo.py
 python tools/validate_manifests.py
 python tools/generate_modlist_markdown.py
 python tools/compare_editions.py

--- a/README.md
+++ b/README.md
@@ -112,7 +112,11 @@ pytest
 - [Pilgrim Edition](ash-archive/editions/openmw/README.md) — OpenMW edition identity and scope
 - [Sleeper Edition](ash-archive/editions/mwse/README.md) — MWSE edition identity and scope
 - [Changelog](ash-archive/CHANGELOG.md)
+<<<<<<< ours
+- [Local Agent Presets](ash-archive/LOCAL-AGENT-PRESETS.md) — repo-scoped agents for safe automated maintenance tasks
+=======
 - [Local Agent Presets](ash-archive/LOCAL-AGENT-PRESETS.md) — planned presets for safe automated maintenance tasks
+>>>>>>> theirs
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ See [ROADMAP.md](ash-archive/ROADMAP.md) for the phased plan and [CHANGELOG.md](
 
 - **Python 3.11+**
 - **PyYAML** (runtime dependency)
-- **pytest** and **ruff** (development/testing)
+- **pytest**, **ruff**, and **yamllint** (development/testing)
 
 ---
 
@@ -61,6 +61,8 @@ pip install -e ".[dev]"
 
 ```
 AshArchive/
+├── .agents/skills/            # Repo-scoped reusable Codex workflows
+├── .codex/agents/             # Repo-scoped Codex agent configurations
 ├── ash-archive/              # Main project root
 │   ├── editions/
 │   │   ├── openmw/           # Pilgrim Edition manifests and docs
@@ -84,6 +86,9 @@ Internal control metadata lives in YAML `.control.meta` files used by project to
 All commands are run from inside `ash-archive/`.
 
 ```bash
+# Lint Python, YAML, agent TOML, and repo skills
+python tools/lint_repo.py
+
 # Validate manifests
 python tools/validate_manifests.py
 
@@ -112,11 +117,7 @@ pytest
 - [Pilgrim Edition](ash-archive/editions/openmw/README.md) — OpenMW edition identity and scope
 - [Sleeper Edition](ash-archive/editions/mwse/README.md) — MWSE edition identity and scope
 - [Changelog](ash-archive/CHANGELOG.md)
-<<<<<<< ours
-- [Local Agent Presets](ash-archive/LOCAL-AGENT-PRESETS.md) — repo-scoped agents for safe automated maintenance tasks
-=======
-- [Local Agent Presets](ash-archive/LOCAL-AGENT-PRESETS.md) — planned presets for safe automated maintenance tasks
->>>>>>> theirs
+- [Local Agent Presets](ash-archive/LOCAL-AGENT-PRESETS.md) — repo-scoped agents and skills for safe maintenance tasks
 
 ---
 

--- a/ash-archive/LOCAL-AGENT-PRESETS.md
+++ b/ash-archive/LOCAL-AGENT-PRESETS.md
@@ -1,6 +1,10 @@
 # Local Agent Presets
 
+<<<<<<< ours
+This document defines reusable local agent presets for routine Ash Archive maintenance. The presets are intentionally conservative: agents may prepare evidence, apply mechanical updates, and run validation, but they must not invent provenance, compatibility evidence, or release readiness.
+=======
 This document plans reusable local agent presets for routine Ash Archive maintenance. The presets are intentionally conservative: agents may prepare evidence, apply mechanical updates, and run validation, but they must not invent provenance, compatibility evidence, or release readiness.
+>>>>>>> theirs
 
 ## Shared operating rules
 
@@ -181,7 +185,11 @@ handoff:
   require_uncertainty_log: true
 ```
 
+<<<<<<< ours
+Preset files live outside generated content in `.agents/presets/`, with one runner-neutral YAML file per preset and a README that points back to this plan. Runnable project-scoped Codex translations live in `.codex/agents/`, with one TOML file per preset. Keep both layers synchronized whenever this policy changes.
+=======
 Preset files live outside generated content in `.agents/presets/`, with one runner-neutral YAML file per preset and a README that points back to this plan. Keep those files synchronized whenever this plan changes.
+>>>>>>> theirs
 
 ## Committed preset files
 
@@ -196,6 +204,27 @@ The repository currently includes runner-neutral YAML presets under `.agents/pre
 
 Use `.agents/presets/README.md` as the local index for maintenance presets and this document as the policy source for guardrails and review gates.
 
+<<<<<<< ours
+## Runnable Codex agents
+
+The repository includes project-scoped Codex agents under `.codex/agents/`. Codex loads
+these agents when the repository is trusted, and the root `AGENTS.md` directs sessions to
+the repository-wide rules. The TOML files are runner-specific translations; the YAML
+presets above remain canonical.
+
+`tests/test_repo_agents.py` verifies that every canonical preset has a matching Codex
+agent and that required reading, forbidden action identifiers, and validation commands are
+preserved in its instructions.
+
+## Automation rollout plan
+
+1. **Document-first pass** - keep this plan as the canonical description of safe agent behavior. **Complete.**
+2. **Repo-agent configuration** - maintain runner-neutral YAML presets and project-scoped Codex TOML translations with automated consistency checks. **Complete.**
+3. **Dry-run prompts** - test each preset against a copied branch and require read-only summaries before allowing edits.
+4. **Mechanical-edit enablement** - allow `manifest-lint-agent` and `modlist-regenerator` to write changes after their checks are stable.
+5. **Evidence workflows** - allow `source-triage-agent` to annotate records only when citations and uncertainty logs are included.
+6. **Release workflows** - keep `release-readiness-agent` advisory-only until Phase 4 release preparation.
+=======
 ## Automation rollout plan
 
 1. **Document-first pass** - keep this plan as the canonical description of safe agent behavior.
@@ -203,6 +232,7 @@ Use `.agents/presets/README.md` as the local index for maintenance presets and t
 3. **Mechanical-edit enablement** - allow `manifest-lint-agent` and `modlist-regenerator` to write changes after their checks are stable.
 4. **Evidence workflows** - allow `source-triage-agent` to annotate records only when citations and uncertainty logs are included.
 5. **Release workflows** - keep `release-readiness-agent` advisory-only until Phase 4 release preparation.
+>>>>>>> theirs
 
 ## Human review gates
 

--- a/ash-archive/LOCAL-AGENT-PRESETS.md
+++ b/ash-archive/LOCAL-AGENT-PRESETS.md
@@ -1,10 +1,6 @@
 # Local Agent Presets
 
-<<<<<<< ours
 This document defines reusable local agent presets for routine Ash Archive maintenance. The presets are intentionally conservative: agents may prepare evidence, apply mechanical updates, and run validation, but they must not invent provenance, compatibility evidence, or release readiness.
-=======
-This document plans reusable local agent presets for routine Ash Archive maintenance. The presets are intentionally conservative: agents may prepare evidence, apply mechanical updates, and run validation, but they must not invent provenance, compatibility evidence, or release readiness.
->>>>>>> theirs
 
 ## Shared operating rules
 
@@ -185,11 +181,7 @@ handoff:
   require_uncertainty_log: true
 ```
 
-<<<<<<< ours
 Preset files live outside generated content in `.agents/presets/`, with one runner-neutral YAML file per preset and a README that points back to this plan. Runnable project-scoped Codex translations live in `.codex/agents/`, with one TOML file per preset. Keep both layers synchronized whenever this policy changes.
-=======
-Preset files live outside generated content in `.agents/presets/`, with one runner-neutral YAML file per preset and a README that points back to this plan. Keep those files synchronized whenever this plan changes.
->>>>>>> theirs
 
 ## Committed preset files
 
@@ -204,7 +196,6 @@ The repository currently includes runner-neutral YAML presets under `.agents/pre
 
 Use `.agents/presets/README.md` as the local index for maintenance presets and this document as the policy source for guardrails and review gates.
 
-<<<<<<< ours
 ## Runnable Codex agents
 
 The repository includes project-scoped Codex agents under `.codex/agents/`. Codex loads
@@ -216,23 +207,34 @@ presets above remain canonical.
 agent and that required reading, forbidden action identifiers, and validation commands are
 preserved in its instructions.
 
+## Repo-scoped skills
+
+Reusable workflows live under `.agents/skills/` and are available throughout the repository:
+
+| Skill | Canonical preset |
+|---|---|
+| `ash-archive-triage-sources` | `source-triage-agent.yaml` |
+| `ash-archive-lint-manifests` | `manifest-lint-agent.yaml` |
+| `ash-archive-regenerate-modlists` | `modlist-regenerator.yaml` |
+| `ash-archive-audit-edition-drift` | `edition-drift-auditor.yaml` |
+| `ash-archive-sync-docs` | `documentation-sync-agent.yaml` |
+| `ash-archive-assess-release` | `release-readiness-agent.yaml` |
+
+Each skill contains concise procedural guidance and generated UI metadata. The preset remains
+the policy source; a skill cannot relax its stop conditions or human review gates.
+
+Run `python tools/lint_repo.py` to lint Python, YAML control metadata, agent TOML, and skill
+metadata. `tests/test_repo_skills.py` also keeps the checked-in skill set under test.
+
 ## Automation rollout plan
 
 1. **Document-first pass** - keep this plan as the canonical description of safe agent behavior. **Complete.**
 2. **Repo-agent configuration** - maintain runner-neutral YAML presets and project-scoped Codex TOML translations with automated consistency checks. **Complete.**
-3. **Dry-run prompts** - test each preset against a copied branch and require read-only summaries before allowing edits.
-4. **Mechanical-edit enablement** - allow `manifest-lint-agent` and `modlist-regenerator` to write changes after their checks are stable.
-5. **Evidence workflows** - allow `source-triage-agent` to annotate records only when citations and uncertainty logs are included.
-6. **Release workflows** - keep `release-readiness-agent` advisory-only until Phase 4 release preparation.
-=======
-## Automation rollout plan
-
-1. **Document-first pass** - keep this plan as the canonical description of safe agent behavior.
-2. **Dry-run prompts** - test each preset against a copied branch and require read-only summaries before allowing edits.
-3. **Mechanical-edit enablement** - allow `manifest-lint-agent` and `modlist-regenerator` to write changes after their checks are stable.
-4. **Evidence workflows** - allow `source-triage-agent` to annotate records only when citations and uncertainty logs are included.
-5. **Release workflows** - keep `release-readiness-agent` advisory-only until Phase 4 release preparation.
->>>>>>> theirs
+3. **Repo-skill configuration** - maintain discoverable repo workflows and lint them against their canonical presets. **Complete.**
+4. **Dry-run prompts** - test each preset against a copied branch and require read-only summaries before allowing edits.
+5. **Mechanical-edit enablement** - allow `manifest-lint-agent` and `modlist-regenerator` to write changes after their checks are stable.
+6. **Evidence workflows** - allow `source-triage-agent` to annotate records only when citations and uncertainty logs are included.
+7. **Release workflows** - keep `release-readiness-agent` advisory-only until Phase 4 release preparation.
 
 ## Human review gates
 

--- a/ash-archive/README.md
+++ b/ash-archive/README.md
@@ -12,9 +12,15 @@ This repository is **planning and scaffold only**. It is not yet a final Wabbaja
 ## Tooling quick start
 From `ash-archive/`:
 
+- Lint Python and repository configuration:
+  - `python tools/lint_repo.py`
 - Validate manifests:
   - `python tools/validate_manifests.py`
 - Generate modlist markdown:
   - `python tools/generate_modlist_markdown.py`
 - Compare editions:
   - `python tools/compare_editions.py`
+- Check for duplicate mods:
+  - `python tools/check_duplicate_mods.py`
+- Run tests:
+  - `pytest`

--- a/ash-archive/pyproject.toml
+++ b/ash-archive/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
 dev = [
   "pytest>=8.0",
   "ruff>=0.4",
+  "yamllint>=1.35",
 ]
 
 [tool.pytest.ini_options]
@@ -18,6 +19,10 @@ testpaths = ["tests"]
 
 [tool.ruff]
 line-length = 100
+target-version = "py311"
+
+[tool.ruff.lint]
+select = ["E4", "E7", "E9", "F", "I", "B", "UP"]
 
 [tool.black]
 line-length = 100

--- a/ash-archive/tests/test_control_meta_conventions.py
+++ b/ash-archive/tests/test_control_meta_conventions.py
@@ -1,6 +1,5 @@
 from pathlib import Path
 
-
 ROOT = Path(__file__).resolve().parents[1]
 
 CONTROL_META_FILES = [

--- a/ash-archive/tests/test_meta_filename_conventions.py
+++ b/ash-archive/tests/test_meta_filename_conventions.py
@@ -1,6 +1,5 @@
 from pathlib import Path
 
-
 ROOT = Path(__file__).resolve().parents[1]
 
 CONTROL_META_FILES = [

--- a/ash-archive/tests/test_repo_agents.py
+++ b/ash-archive/tests/test_repo_agents.py
@@ -1,0 +1,56 @@
+from pathlib import Path
+import tomllib
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PRESET_DIR = REPO_ROOT / ".agents" / "presets"
+AGENT_DIR = REPO_ROOT / ".codex" / "agents"
+
+
+def _yaml_presets() -> dict[str, dict]:
+    return {
+        path.stem: yaml.safe_load(path.read_text(encoding="utf-8"))
+        for path in PRESET_DIR.glob("*.yaml")
+    }
+
+
+def _toml_agents() -> dict[str, dict]:
+    return {
+        path.stem: tomllib.loads(path.read_text(encoding="utf-8"))
+        for path in AGENT_DIR.glob("*.toml")
+    }
+
+
+def test_repo_agent_set_matches_canonical_presets() -> None:
+    assert _toml_agents().keys() == _yaml_presets().keys()
+
+
+def test_repo_agents_include_required_codex_fields_and_preset_guardrails() -> None:
+    presets = _yaml_presets()
+
+    for stem, agent in _toml_agents().items():
+        assert agent["name"] == stem
+        assert agent["description"].strip()
+        instructions = agent["developer_instructions"]
+        assert instructions.strip()
+
+        preset = presets[stem]
+        for required_path in preset.get("read_before_editing", []):
+            assert required_path in instructions, f"{stem} does not require reading {required_path}"
+        for forbidden_action in preset.get("forbidden_actions", []):
+            assert forbidden_action in instructions, (
+                f"{stem} does not preserve forbidden action {forbidden_action}"
+            )
+        for check in preset.get("required_checks", []):
+            assert check["command"] in instructions, (
+                f"{stem} does not preserve required check {check['command']}"
+            )
+
+
+def test_root_agents_file_loads_repository_policy() -> None:
+    guidance = (REPO_ROOT / "AGENTS.md").read_text(encoding="utf-8")
+    assert "AGENT-RULES.md" in guidance
+    assert "ash-archive/PROJECT-BIBLE.md" in guidance
+    assert ".codex/agents/" in guidance

--- a/ash-archive/tests/test_repo_agents.py
+++ b/ash-archive/tests/test_repo_agents.py
@@ -1,8 +1,7 @@
-from pathlib import Path
 import tomllib
+from pathlib import Path
 
 import yaml
-
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 PRESET_DIR = REPO_ROOT / ".agents" / "presets"

--- a/ash-archive/tests/test_repo_skills.py
+++ b/ash-archive/tests/test_repo_skills.py
@@ -1,0 +1,6 @@
+from tools.lint_repo import SKILL_PRESETS, validate_repo_configuration
+
+
+def test_repo_skill_workflows_are_complete() -> None:
+    assert len(SKILL_PRESETS) == 6
+    assert validate_repo_configuration() == []

--- a/ash-archive/tests/test_sourced_mods.py
+++ b/ash-archive/tests/test_sourced_mods.py
@@ -1,12 +1,11 @@
 from __future__ import annotations
 
-from pathlib import Path
 import subprocess
+from pathlib import Path
 
 import yaml
 
 from tools.lib.sourced_mods import validate_sourced_mods
-
 
 FIXTURE_REQUIRED_FIELDS = {
     "id": "sample-candidate",
@@ -31,7 +30,9 @@ FIXTURE_REQUIRED_FIELDS = {
 
 
 def _write_sourced(path: Path, entries: list[dict]) -> None:
-    path.write_text(yaml.safe_dump({"sourced_candidates": entries}, sort_keys=False), encoding="utf-8")
+    path.write_text(
+        yaml.safe_dump({"sourced_candidates": entries}, sort_keys=False), encoding="utf-8"
+    )
 
 
 def test_valid_sourced_fixture_passes() -> None:

--- a/ash-archive/tests/test_validation.py
+++ b/ash-archive/tests/test_validation.py
@@ -5,7 +5,6 @@ import yaml
 
 from tools.lib.validation import validate_manifest
 
-
 FIXTURE_REQUIRED_FIELDS = {
     "id": "sample-mod",
     "name": "Sample Mod",

--- a/ash-archive/tools/lib/sourced_mods.py
+++ b/ash-archive/tools/lib/sourced_mods.py
@@ -106,17 +106,25 @@ def validate_candidate(candidate: dict, path: Path) -> list[str]:
 
     if candidate["candidate_status"] not in CANDIDATE_STATUS:
         errors.append(
-            _format_error(path, mod_ref, f"invalid candidate_status {candidate['candidate_status']!r}")
+            _format_error(
+                path, mod_ref, f"invalid candidate_status {candidate['candidate_status']!r}"
+            )
         )
     if candidate["thematic_bucket"] not in THEMATIC_BUCKETS:
         errors.append(
-            _format_error(path, mod_ref, f"invalid thematic_bucket {candidate['thematic_bucket']!r}")
+            _format_error(
+                path, mod_ref, f"invalid thematic_bucket {candidate['thematic_bucket']!r}"
+            )
         )
     if candidate["source_type"] not in SOURCE_TYPES:
-        errors.append(_format_error(path, mod_ref, f"invalid source_type {candidate['source_type']!r}"))
+        errors.append(
+            _format_error(path, mod_ref, f"invalid source_type {candidate['source_type']!r}")
+        )
     if candidate["source_confidence"] not in SOURCE_CONFIDENCE:
         errors.append(
-            _format_error(path, mod_ref, f"invalid source_confidence {candidate['source_confidence']!r}")
+            _format_error(
+                path, mod_ref, f"invalid source_confidence {candidate['source_confidence']!r}"
+            )
         )
     if candidate["compatibility_status"] not in COMPATIBILITY_STATUS:
         errors.append(
@@ -127,22 +135,32 @@ def validate_candidate(candidate: dict, path: Path) -> list[str]:
             )
         )
     if candidate["risk_level"] not in RISK_LEVELS:
-        errors.append(_format_error(path, mod_ref, f"invalid risk_level {candidate['risk_level']!r}"))
+        errors.append(
+            _format_error(path, mod_ref, f"invalid risk_level {candidate['risk_level']!r}")
+        )
     if candidate["promotion_target"] not in PROMOTION_TARGETS:
         errors.append(
-            _format_error(path, mod_ref, f"invalid promotion_target {candidate['promotion_target']!r}")
+            _format_error(
+                path, mod_ref, f"invalid promotion_target {candidate['promotion_target']!r}"
+            )
         )
 
     intended_editions = candidate["intended_editions"]
     if not isinstance(intended_editions, list) or not intended_editions:
-        errors.append(_format_error(path, mod_ref, "field 'intended_editions' must be a non-empty list"))
+        errors.append(
+            _format_error(path, mod_ref, "field 'intended_editions' must be a non-empty list")
+        )
     elif any(not isinstance(edition, str) for edition in intended_editions):
         errors.append(_format_error(path, mod_ref, "field 'intended_editions' must be list[str]"))
     else:
-        invalid_editions = [edition for edition in intended_editions if edition not in INTENDED_EDITIONS]
+        invalid_editions = [
+            edition for edition in intended_editions if edition not in INTENDED_EDITIONS
+        ]
         if invalid_editions:
             errors.append(
-                _format_error(path, mod_ref, f"invalid intended_editions values {invalid_editions!r}")
+                _format_error(
+                    path, mod_ref, f"invalid intended_editions values {invalid_editions!r}"
+                )
             )
 
     for field_name in ("reviewed_by", "related_manifest_ids"):

--- a/ash-archive/tools/lib/validation.py
+++ b/ash-archive/tools/lib/validation.py
@@ -4,7 +4,7 @@ import re
 from functools import lru_cache
 from pathlib import Path
 
-from .manifest import load_mods, load_meta_document
+from .manifest import load_meta_document, load_mods
 from .paths import categories_path
 
 ID_RE = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")

--- a/ash-archive/tools/lint_repo.py
+++ b/ash-archive/tools/lint_repo.py
@@ -1,0 +1,193 @@
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+import tomllib
+from pathlib import Path
+
+import yaml
+from yamllint import linter as yaml_linter
+from yamllint.config import YamlLintConfig
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+REPO_ROOT = PROJECT_ROOT.parent
+PRESET_ROOT = REPO_ROOT / ".agents" / "presets"
+SKILL_ROOT = REPO_ROOT / ".agents" / "skills"
+AGENT_ROOT = REPO_ROOT / ".codex" / "agents"
+SKILL_NAME_PATTERN = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
+
+SKILL_PRESETS = {
+    "ash-archive-triage-sources": "source-triage-agent.yaml",
+    "ash-archive-lint-manifests": "manifest-lint-agent.yaml",
+    "ash-archive-regenerate-modlists": "modlist-regenerator.yaml",
+    "ash-archive-audit-edition-drift": "edition-drift-auditor.yaml",
+    "ash-archive-sync-docs": "documentation-sync-agent.yaml",
+    "ash-archive-assess-release": "release-readiness-agent.yaml",
+}
+
+
+def _relative(path: Path) -> str:
+    return path.relative_to(REPO_ROOT).as_posix()
+
+
+def _load_skill(path: Path) -> tuple[dict, str]:
+    text = path.read_text(encoding="utf-8")
+    lines = text.splitlines()
+    if not lines or lines[0] != "---":
+        raise ValueError("SKILL.md must begin with YAML frontmatter")
+
+    try:
+        closing_index = lines.index("---", 1)
+    except ValueError as error:
+        raise ValueError("SKILL.md frontmatter is not closed") from error
+
+    metadata = yaml.safe_load("\n".join(lines[1:closing_index]))
+    if not isinstance(metadata, dict):
+        raise ValueError("SKILL.md frontmatter must be a mapping")
+    return metadata, "\n".join(lines[closing_index + 1 :])
+
+
+def _find_conflict_markers() -> list[str]:
+    patterns = ("*.md", "*.py", "*.toml", "*.yaml", "*.yml", "*.control.meta")
+    paths = {path for pattern in patterns for path in REPO_ROOT.rglob(pattern)}
+    issues: list[str] = []
+
+    for path in sorted(paths):
+        if any(part in {".git", ".pytest_cache", "__pycache__"} for part in path.parts):
+            continue
+        for line_number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+            if line.startswith("<<<<<<< ") or line == "=======" or line.startswith(">>>>>>> "):
+                issues.append(f"{_relative(path)}:{line_number}: unresolved merge marker")
+
+    return issues
+
+
+def validate_repo_configuration() -> list[str]:
+    issues = _find_conflict_markers()
+
+    pyproject_path = PROJECT_ROOT / "pyproject.toml"
+    try:
+        tomllib.loads(pyproject_path.read_text(encoding="utf-8"))
+    except (OSError, tomllib.TOMLDecodeError) as error:
+        issues.append(f"{_relative(pyproject_path)}: invalid TOML: {error}")
+
+    preset_names = {path.stem for path in PRESET_ROOT.glob("*.yaml")}
+    agent_names = {path.stem for path in AGENT_ROOT.glob("*.toml")}
+    if preset_names != agent_names:
+        issues.append(
+            "agent TOML files must match preset YAML files: "
+            f"presets={sorted(preset_names)}, agents={sorted(agent_names)}"
+        )
+
+    for agent_path in sorted(AGENT_ROOT.glob("*.toml")):
+        try:
+            agent = tomllib.loads(agent_path.read_text(encoding="utf-8"))
+        except (OSError, tomllib.TOMLDecodeError) as error:
+            issues.append(f"{_relative(agent_path)}: invalid TOML: {error}")
+            continue
+
+        missing = {"name", "description", "developer_instructions"} - agent.keys()
+        if missing:
+            issues.append(f"{_relative(agent_path)}: missing fields {sorted(missing)}")
+        if agent.get("name") != agent_path.stem:
+            issues.append(f"{_relative(agent_path)}: name must match the filename stem")
+
+    skill_names = {path.parent.name for path in SKILL_ROOT.glob("*/SKILL.md")}
+    if skill_names != SKILL_PRESETS.keys():
+        issues.append(
+            "repo skill set does not match the expected workflows: "
+            f"expected={sorted(SKILL_PRESETS)}, actual={sorted(skill_names)}"
+        )
+
+    for skill_name, preset_name in SKILL_PRESETS.items():
+        skill_path = SKILL_ROOT / skill_name / "SKILL.md"
+        try:
+            metadata, body = _load_skill(skill_path)
+        except (OSError, yaml.YAMLError, ValueError) as error:
+            issues.append(f"{_relative(skill_path)}: {error}")
+            continue
+
+        if set(metadata) != {"name", "description"}:
+            issues.append(
+                f"{_relative(skill_path)}: frontmatter may only contain name and description"
+            )
+        if metadata.get("name") != skill_name:
+            issues.append(f"{_relative(skill_path)}: name must match its directory")
+        if not SKILL_NAME_PATTERN.fullmatch(str(metadata.get("name", ""))):
+            issues.append(f"{_relative(skill_path)}: name must use lowercase hyphen-case")
+        if not str(metadata.get("description", "")).strip():
+            issues.append(f"{_relative(skill_path)}: description must not be empty")
+        if "TODO" in body:
+            issues.append(f"{_relative(skill_path)}: unresolved TODO remains")
+        if f".agents/presets/{preset_name}" not in body:
+            issues.append(
+                f"{_relative(skill_path)}: canonical preset {preset_name} is not referenced"
+            )
+
+        interface_path = skill_path.parent / "agents" / "openai.yaml"
+        try:
+            interface_data = yaml.safe_load(interface_path.read_text(encoding="utf-8"))
+            interface = interface_data["interface"]
+        except (OSError, KeyError, TypeError, yaml.YAMLError) as error:
+            issues.append(f"{_relative(interface_path)}: invalid interface metadata: {error}")
+            continue
+
+        required_fields = {"display_name", "short_description", "default_prompt"}
+        missing_fields = required_fields - interface.keys()
+        if missing_fields:
+            issues.append(f"{_relative(interface_path)}: missing fields {sorted(missing_fields)}")
+            continue
+
+        short_description = interface["short_description"]
+        if not 25 <= len(short_description) <= 64:
+            issues.append(
+                f"{_relative(interface_path)}: short_description must be 25-64 characters"
+            )
+        if f"${skill_name}" not in interface["default_prompt"]:
+            issues.append(f"{_relative(interface_path)}: default_prompt must mention ${skill_name}")
+
+    return issues
+
+
+def lint_yaml() -> list[str]:
+    config = YamlLintConfig((REPO_ROOT / ".yamllint.yml").read_text(encoding="utf-8"))
+    yaml_paths = {
+        *REPO_ROOT.rglob("*.yaml"),
+        *REPO_ROOT.rglob("*.yml"),
+        *PROJECT_ROOT.rglob("*.control.meta"),
+    }
+    issues: list[str] = []
+
+    for path in sorted(yaml_paths):
+        if any(part in {".git", ".pytest_cache", "__pycache__"} for part in path.parts):
+            continue
+        text = path.read_text(encoding="utf-8")
+        for problem in yaml_linter.run(text, config, filepath=_relative(path)):
+            issues.append(str(problem))
+
+    return issues
+
+
+def _run_ruff(arguments: list[str]) -> int:
+    command = [sys.executable, "-m", "ruff", *arguments]
+    print(f"[RUN] {' '.join(command)}", flush=True)
+    return subprocess.run(command, cwd=PROJECT_ROOT, check=False).returncode
+
+
+def main() -> int:
+    issues = [*validate_repo_configuration(), *lint_yaml()]
+    for issue in issues:
+        print(f"[ERROR] {issue}")
+
+    ruff_check = _run_ruff(["check", "tools", "tests"])
+    ruff_format = _run_ruff(["format", "--check", "tools", "tests"])
+    if issues or ruff_check or ruff_format:
+        return 1
+
+    print("[OK] Repository configuration, YAML, and Python lint checks passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ash-archive/tools/summarize_sourced_mods.py
+++ b/ash-archive/tools/summarize_sourced_mods.py
@@ -8,7 +8,6 @@ from pathlib import Path
 from lib.paths import ROOT
 from lib.sourced_mods import validate_sourced_mods
 
-
 SUMMARY_FIELDS = [
     "candidate_status",
     "intended_editions",
@@ -19,7 +18,9 @@ SUMMARY_FIELDS = [
 
 
 def _parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description="Summarize sourced-mod candidates by thematic bucket.")
+    parser = argparse.ArgumentParser(
+        description="Summarize sourced-mod candidates by thematic bucket."
+    )
     parser.add_argument(
         "--file",
         type=Path,
@@ -48,8 +49,12 @@ def main() -> int:
 
     for bucket in sorted(grouped):
         print(f"[{bucket}]")
-        print("id | name | candidate_status | intended_editions | compatibility_status | risk_level | source_confidence")
-        print("-- | ---- | ---------------- | ----------------- | -------------------- | ---------- | -----------------")
+        print(
+            "id | name | candidate_status | intended_editions | compatibility_status | risk_level | source_confidence"
+        )
+        print(
+            "-- | ---- | ---------------- | ----------------- | -------------------- | ---------- | -----------------"
+        )
         for candidate in sorted(grouped[bucket], key=lambda item: item["id"]):
             row = [candidate["id"], candidate["name"]]
             for field in SUMMARY_FIELDS:


### PR DESCRIPTION
## Summary
- Add `.codex/agents/` README plus TOML agents for the repo maintenance presets
- Document the relationship between runner-neutral YAML presets and runnable Codex translations
- Add tests to verify agent coverage, required guardrails, and repository-level agent guidance
- Update root and preset documentation to point to the new agent workflow

## Testing
- Not run (not requested)