### PR TITLE
Add archive planning skills and pre-merge integrity checks

### DIFF
--- a/.agents/presets/README.md
+++ b/.agents/presets/README.md
@@ -17,6 +17,8 @@ forbidden actions, checks, and human review gates.
 | [`edition-drift-auditor.yaml`](edition-drift-auditor.yaml) | Audit OpenMW/MWSE divergence and duplicate risks. |
 | [`documentation-sync-agent.yaml`](documentation-sync-agent.yaml) | Synchronize planning, policy, and workflow documentation. |
 | [`release-readiness-agent.yaml`](release-readiness-agent.yaml) | Prepare advisory release-readiness and blocker summaries. |
+| [`wabbajack-list-planner.yaml`](wabbajack-list-planner.yaml) | Prepare nonbinding, evidence-backed dual-edition list plans. |
+| [`wabbajack-list-writer.yaml`](wabbajack-list-writer.yaml) | Draft evidence-backed, edition-specific Wabbajack prose. |
 
 ## Runner expectations
 

--- a/.agents/presets/wabbajack-list-planner.yaml
+++ b/.agents/presets/wabbajack-list-planner.yaml
@@ -1,0 +1,74 @@
+name: wabbajack-list-planner
+purpose: Prepare taste-aligned, evidence-backed plans for the two Ash Archive lists.
+mode: advisory-planning
+scope:
+  - ash-archive/PROJECT-BIBLE.md
+  - ash-archive/ROADMAP.md
+  - ash-archive/FOLLOW-UP-TASKS.md
+  - ash-archive/shared/*.control.meta
+  - ash-archive/editions/openmw/README.md
+  - ash-archive/editions/mwse/README.md
+  - ash-archive/editions/openmw/manifests/*.control.meta
+  - ash-archive/editions/mwse/manifests/*.control.meta
+  - ash-archive/editions/openmw/wabbajack/*.md
+  - ash-archive/editions/mwse/wabbajack/*.md
+read_before_editing:
+  - AGENT-RULES.md
+  - ash-archive/LOCAL-AGENT-PRESETS.md
+  - ash-archive/PROJECT-BIBLE.md
+  - ash-archive/ROADMAP.md
+  - ash-archive/shared/sourced-mod-workflow.md
+  - ash-archive/editions/openmw/README.md
+  - ash-archive/editions/mwse/README.md
+preference_source: ash-archive/PROJECT-BIBLE.md
+taste_lenses:
+  - morrowind_native_psychological_horror
+  - silent_hill_2_spatial_guilt_without_crossover
+  - david_lynch_dream_causality_doubles_and_repetition_without_pastiche
+  - lake_mungo_archive_first_foreshadowing_without_imitation
+  - evidence_before_explanation
+allowed_actions:
+  - analyze_category_coverage
+  - map_candidates_to_evaluation_batches
+  - propose_edition_specific_direction
+  - identify_evidence_and_sourcing_gaps
+  - draft_nonbinding_list_plans
+  - distinguish_shared_pillars_from_engine_specific_execution
+forbidden_actions:
+  - accept_or_reject_mods
+  - promote_candidates_without_human_review
+  - finalize_load_order
+  - invent_provenance_versions_or_compatibility_evidence
+  - claim_compatibility_without_test_evidence
+  - force_cross_edition_parity
+  - introduce_direct_crossover_content
+  - change_design_pillars_without_human_review
+required_checks:
+  - working_directory: ash-archive
+    command: python tools/validate_manifests.py
+    when: plan_uses_current_manifest_or_candidate_inventory
+  - working_directory: ash-archive
+    command: python tools/compare_editions.py
+    when: plan_compares_or_rebalances_editions
+  - working_directory: ash-archive
+    command: python tools/check_duplicate_mods.py
+    when: plan_recommends_candidate_placement
+stop_conditions:
+  - candidate_fit_requires_unrecorded_compatibility_or_source_evidence
+  - edition_placement_requires_human_design_judgment
+  - requested_direction_conflicts_with_project_bible
+  - personal_preference_is_not_recorded_in_the_project_bible
+handoff:
+  require_summary: true
+  separate_facts_interpretations_and_recommendations: true
+  separate_pilgrim_and_sleeper_plans: true
+  list_evidence_gaps_and_human_decisions: true
+  include_exact_validation_commands: true
+  state_skipped_checks_with_reason: true
+human_review_required_for:
+  - mod_acceptance_or_rejection
+  - candidate_promotion
+  - final_edition_placement
+  - load_order_decisions
+  - design_pillar_or_taste_profile_changes
+  - roadmap_phase_gate_changes

--- a/.agents/presets/wabbajack-list-writer.yaml
+++ b/.agents/presets/wabbajack-list-writer.yaml
@@ -1,0 +1,77 @@
+name: wabbajack-list-writer
+purpose: Draft restrained, lore-native Wabbajack prose from verified repository evidence.
+mode: evidence-backed-prose
+scope:
+  - README.md
+  - ash-archive/README.md
+  - ash-archive/editions/openmw/README.md
+  - ash-archive/editions/mwse/README.md
+  - ash-archive/editions/openmw/CHANGELOG.md
+  - ash-archive/editions/mwse/CHANGELOG.md
+  - ash-archive/editions/openmw/wabbajack/*.md
+  - ash-archive/editions/mwse/wabbajack/*.md
+  - ash-archive/editions/openmw/docs/installation.md
+  - ash-archive/editions/openmw/docs/post-install.md
+  - ash-archive/editions/openmw/docs/known-issues.md
+  - ash-archive/editions/mwse/docs/installation.md
+  - ash-archive/editions/mwse/docs/post-install.md
+  - ash-archive/editions/mwse/docs/known-issues.md
+read_before_editing:
+  - AGENT-RULES.md
+  - ash-archive/LOCAL-AGENT-PRESETS.md
+  - ash-archive/PROJECT-BIBLE.md
+  - ash-archive/ROADMAP.md
+  - ash-archive/editions/openmw/README.md
+  - ash-archive/editions/mwse/README.md
+preference_source: ash-archive/PROJECT-BIBLE.md
+taste_lenses:
+  - morrowind_native_psychological_horror
+  - silent_hill_2_spatial_guilt_without_crossover
+  - david_lynch_dream_causality_doubles_and_repetition_without_pastiche
+  - lake_mungo_archive_first_foreshadowing_without_imitation
+  - evidence_before_explanation
+voice_rules:
+  - translate_influences_into_morrowind_native_logic
+  - use_restrained_archival_prose
+  - let_evidence_precede_explanation
+  - emphasize_distance_weather_documents_and_retrospective_dread_for_pilgrim
+  - emphasize_dreams_doubles_identity_fracture_and_ritual_repetition_for_sleeper
+  - prefer_operational_clarity_over_atmosphere_in_instructions_and_warnings
+allowed_actions:
+  - draft_wabbajack_list_descriptions
+  - rewrite_verified_feature_and_atmosphere_copy
+  - draft_installer_facing_guidance
+  - draft_release_notes_from_recorded_changes
+  - preserve_distinct_pilgrim_and_sleeper_voices
+  - label_draft_claims_that_need_evidence_or_review
+forbidden_actions:
+  - invent_features_sources_versions_or_test_results
+  - claim_installability_compatibility_or_release_readiness_without_evidence
+  - copy_media_language_or_introduce_direct_crossover_content
+  - obscure_requirements_warnings_or_known_issues_for_atmosphere
+  - collapse_pilgrim_and_sleeper_into_one_voice
+  - hand_edit_generated_modlist_sections
+  - change_design_pillars_or_support_boundaries_without_human_review
+required_checks:
+  - working_directory: ash-archive
+    command: python tools/validate_manifests.py
+    when: prose_names_included_content_status_or_compatibility
+  - working_directory: ash-archive
+    command: pytest
+    when: tooling_backed_docs_or_tests_change
+stop_conditions:
+  - requested_claim_lacks_repository_evidence
+  - final_public_voice_requires_unrecorded_personal_preference
+  - prose_would_hide_a_support_or_installation_constraint
+  - requested_direction_conflicts_with_project_bible
+handoff:
+  require_summary: true
+  identify_factual_sources_for_material_claims: true
+  list_draft_claims_requiring_review: true
+  distinguish_pilgrim_and_sleeper_copy: true
+  state_skipped_checks_with_reason: true
+human_review_required_for:
+  - final_public_facing_copy
+  - release_readiness_or_installability_claims
+  - support_boundary_changes
+  - design_pillar_or_taste_profile_changes

--- a/.agents/skills/ash-archive-plan-wabbajack-list/SKILL.md
+++ b/.agents/skills/ash-archive-plan-wabbajack-list/SKILL.md
@@ -1,85 +1,32 @@
 ---
 name: ash-archive-plan-wabbajack-list
-description: [TODO: Complete and informative explanation of what the skill does and when to use it. Include WHEN to use this skill - specific scenarios, file types, or tasks that trigger it.]
+description: Prepare taste-aligned, evidence-backed plans for the Ash Archive Pilgrim and Sleeper Wabbajack lists. Use for category coverage, evaluation batches, edition fit, evidence gaps, or nonbinding list direction; never accept mods, promote candidates, finalize load order, or invent compatibility.
 ---
 
-# Ash Archive Plan Wabbajack List
+# Plan Ash Archive Wabbajack Lists
 
-## Overview
+## Workflow
 
-[TODO: 1-2 sentences explaining what this skill enables]
+1. Read `AGENT-RULES.md`, `ash-archive/PROJECT-BIBLE.md`,
+   `ash-archive/LOCAL-AGENT-PRESETS.md`,
+   `.agents/presets/wabbajack-list-planner.yaml`, `ash-archive/ROADMAP.md`,
+   `ash-archive/shared/sourced-mod-workflow.md`, and both edition README files.
+2. Treat the project bible as the preference source. Translate its media lenses into
+   Morrowind-native design; do not imitate or introduce crossover content. Surface any
+   preference needed by the task that the project bible does not record.
+3. Inventory repository evidence before recommending direction. Separate sourced facts,
+   interpretations, recommendations, evidence gaps, and human decisions.
+4. Plan Pilgrim around atmospheric long-play stability and retrospective dread. Plan
+   Sleeper around reactive dream, ritual, and identity systems. Do not force parity.
+5. From `ash-archive/`, run `python tools/lint_repo.py`. Run
+   `python tools/validate_manifests.py` when using current inventory,
+   `python tools/compare_editions.py` for cross-edition plans, and
+   `python tools/check_duplicate_mods.py` when recommending candidate placement.
+6. Report separate edition plans, exact command results, skipped checks with reasons, and
+   the evidence or human decision needed for every unresolved point.
 
-## Structuring This Skill
+## Stop Conditions
 
-[TODO: Choose the structure that best fits this skill's purpose. Common patterns:
-
-**1. Workflow-Based** (best for sequential processes)
-- Works well when there are clear step-by-step procedures
-- Example: DOCX skill with "Workflow Decision Tree" -> "Reading" -> "Creating" -> "Editing"
-- Structure: ## Overview -> ## Workflow Decision Tree -> ## Step 1 -> ## Step 2...
-
-**2. Task-Based** (best for tool collections)
-- Works well when the skill offers different operations/capabilities
-- Example: PDF skill with "Quick Start" -> "Merge PDFs" -> "Split PDFs" -> "Extract Text"
-- Structure: ## Overview -> ## Quick Start -> ## Task Category 1 -> ## Task Category 2...
-
-**3. Reference/Guidelines** (best for standards or specifications)
-- Works well for brand guidelines, coding standards, or requirements
-- Example: Brand styling with "Brand Guidelines" -> "Colors" -> "Typography" -> "Features"
-- Structure: ## Overview -> ## Guidelines -> ## Specifications -> ## Usage...
-
-**4. Capabilities-Based** (best for integrated systems)
-- Works well when the skill provides multiple interrelated features
-- Example: Product Management with "Core Capabilities" -> numbered capability list
-- Structure: ## Overview -> ## Core Capabilities -> ### 1. Feature -> ### 2. Feature...
-
-Patterns can be mixed and matched as needed. Most skills combine patterns (e.g., start with task-based, add workflow for complex operations).
-
-Delete this entire "Structuring This Skill" section when done - it's just guidance.]
-
-## [TODO: Replace with the first main section based on chosen structure]
-
-[TODO: Add content here. See examples in existing skills:
-- Code samples for technical skills
-- Decision trees for complex workflows
-- Concrete examples with realistic user requests
-- References to scripts/templates/references as needed]
-
-## Resources (optional)
-
-Create only the resource directories this skill actually needs. Delete this section if no resources are required.
-
-### scripts/
-Executable code (Python/Bash/etc.) that can be run directly to perform specific operations.
-
-**Examples from other skills:**
-- PDF skill: `fill_fillable_fields.py`, `extract_form_field_info.py` - utilities for PDF manipulation
-- DOCX skill: `document.py`, `utilities.py` - Python modules for document processing
-
-**Appropriate for:** Python scripts, shell scripts, or any executable code that performs automation, data processing, or specific operations.
-
-**Note:** Scripts may be executed without loading into context, but can still be read by Codex for patching or environment adjustments.
-
-### references/
-Documentation and reference material intended to be loaded into context to inform Codex's process and thinking.
-
-**Examples from other skills:**
-- Product management: `communication.md`, `context_building.md` - detailed workflow guides
-- BigQuery: API reference documentation and query examples
-- Finance: Schema documentation, company policies
-
-**Appropriate for:** In-depth documentation, API references, database schemas, comprehensive guides, or any detailed information that Codex should reference while working.
-
-### assets/
-Files not intended to be loaded into context, but rather used within the output Codex produces.
-
-**Examples from other skills:**
-- Brand styling: PowerPoint template files (.pptx), logo files
-- Frontend builder: HTML/React boilerplate project directories
-- Typography: Font files (.ttf, .woff2)
-
-**Appropriate for:** Templates, boilerplate code, document templates, images, icons, fonts, or any files meant to be copied or used in the final output.
-
----
-
-**Not every skill requires all three types of resources.**
+Stop before accepting or rejecting mods, promoting candidates, finalizing edition
+placement or load order, changing phase gates or taste rules, or resolving a plan that
+depends on unrecorded provenance, compatibility evidence, or personal preference.

--- a/.agents/skills/ash-archive-plan-wabbajack-list/SKILL.md
+++ b/.agents/skills/ash-archive-plan-wabbajack-list/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: ash-archive-plan-wabbajack-list
+description: [TODO: Complete and informative explanation of what the skill does and when to use it. Include WHEN to use this skill - specific scenarios, file types, or tasks that trigger it.]
+---
+
+# Ash Archive Plan Wabbajack List
+
+## Overview
+
+[TODO: 1-2 sentences explaining what this skill enables]
+
+## Structuring This Skill
+
+[TODO: Choose the structure that best fits this skill's purpose. Common patterns:
+
+**1. Workflow-Based** (best for sequential processes)
+- Works well when there are clear step-by-step procedures
+- Example: DOCX skill with "Workflow Decision Tree" -> "Reading" -> "Creating" -> "Editing"
+- Structure: ## Overview -> ## Workflow Decision Tree -> ## Step 1 -> ## Step 2...
+
+**2. Task-Based** (best for tool collections)
+- Works well when the skill offers different operations/capabilities
+- Example: PDF skill with "Quick Start" -> "Merge PDFs" -> "Split PDFs" -> "Extract Text"
+- Structure: ## Overview -> ## Quick Start -> ## Task Category 1 -> ## Task Category 2...
+
+**3. Reference/Guidelines** (best for standards or specifications)
+- Works well for brand guidelines, coding standards, or requirements
+- Example: Brand styling with "Brand Guidelines" -> "Colors" -> "Typography" -> "Features"
+- Structure: ## Overview -> ## Guidelines -> ## Specifications -> ## Usage...
+
+**4. Capabilities-Based** (best for integrated systems)
+- Works well when the skill provides multiple interrelated features
+- Example: Product Management with "Core Capabilities" -> numbered capability list
+- Structure: ## Overview -> ## Core Capabilities -> ### 1. Feature -> ### 2. Feature...
+
+Patterns can be mixed and matched as needed. Most skills combine patterns (e.g., start with task-based, add workflow for complex operations).
+
+Delete this entire "Structuring This Skill" section when done - it's just guidance.]
+
+## [TODO: Replace with the first main section based on chosen structure]
+
+[TODO: Add content here. See examples in existing skills:
+- Code samples for technical skills
+- Decision trees for complex workflows
+- Concrete examples with realistic user requests
+- References to scripts/templates/references as needed]
+
+## Resources (optional)
+
+Create only the resource directories this skill actually needs. Delete this section if no resources are required.
+
+### scripts/
+Executable code (Python/Bash/etc.) that can be run directly to perform specific operations.
+
+**Examples from other skills:**
+- PDF skill: `fill_fillable_fields.py`, `extract_form_field_info.py` - utilities for PDF manipulation
+- DOCX skill: `document.py`, `utilities.py` - Python modules for document processing
+
+**Appropriate for:** Python scripts, shell scripts, or any executable code that performs automation, data processing, or specific operations.
+
+**Note:** Scripts may be executed without loading into context, but can still be read by Codex for patching or environment adjustments.
+
+### references/
+Documentation and reference material intended to be loaded into context to inform Codex's process and thinking.
+
+**Examples from other skills:**
+- Product management: `communication.md`, `context_building.md` - detailed workflow guides
+- BigQuery: API reference documentation and query examples
+- Finance: Schema documentation, company policies
+
+**Appropriate for:** In-depth documentation, API references, database schemas, comprehensive guides, or any detailed information that Codex should reference while working.
+
+### assets/
+Files not intended to be loaded into context, but rather used within the output Codex produces.
+
+**Examples from other skills:**
+- Brand styling: PowerPoint template files (.pptx), logo files
+- Frontend builder: HTML/React boilerplate project directories
+- Typography: Font files (.ttf, .woff2)
+
+**Appropriate for:** Templates, boilerplate code, document templates, images, icons, fonts, or any files meant to be copied or used in the final output.
+
+---
+
+**Not every skill requires all three types of resources.**

--- a/.agents/skills/ash-archive-plan-wabbajack-list/agents/openai.yaml
+++ b/.agents/skills/ash-archive-plan-wabbajack-list/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Ash Archive Wabbajack Planning"
+  short_description: "Evidence-first dual-edition list planning"
+  default_prompt: "Use $ash-archive-plan-wabbajack-list to prepare a taste-aligned, evidence-backed plan for the Pilgrim and Sleeper editions."

--- a/.agents/skills/ash-archive-write-wabbajack-copy/SKILL.md
+++ b/.agents/skills/ash-archive-write-wabbajack-copy/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: ash-archive-write-wabbajack-copy
+description: [TODO: Complete and informative explanation of what the skill does and when to use it. Include WHEN to use this skill - specific scenarios, file types, or tasks that trigger it.]
+---
+
+# Ash Archive Write Wabbajack Copy
+
+## Overview
+
+[TODO: 1-2 sentences explaining what this skill enables]
+
+## Structuring This Skill
+
+[TODO: Choose the structure that best fits this skill's purpose. Common patterns:
+
+**1. Workflow-Based** (best for sequential processes)
+- Works well when there are clear step-by-step procedures
+- Example: DOCX skill with "Workflow Decision Tree" -> "Reading" -> "Creating" -> "Editing"
+- Structure: ## Overview -> ## Workflow Decision Tree -> ## Step 1 -> ## Step 2...
+
+**2. Task-Based** (best for tool collections)
+- Works well when the skill offers different operations/capabilities
+- Example: PDF skill with "Quick Start" -> "Merge PDFs" -> "Split PDFs" -> "Extract Text"
+- Structure: ## Overview -> ## Quick Start -> ## Task Category 1 -> ## Task Category 2...
+
+**3. Reference/Guidelines** (best for standards or specifications)
+- Works well for brand guidelines, coding standards, or requirements
+- Example: Brand styling with "Brand Guidelines" -> "Colors" -> "Typography" -> "Features"
+- Structure: ## Overview -> ## Guidelines -> ## Specifications -> ## Usage...
+
+**4. Capabilities-Based** (best for integrated systems)
+- Works well when the skill provides multiple interrelated features
+- Example: Product Management with "Core Capabilities" -> numbered capability list
+- Structure: ## Overview -> ## Core Capabilities -> ### 1. Feature -> ### 2. Feature...
+
+Patterns can be mixed and matched as needed. Most skills combine patterns (e.g., start with task-based, add workflow for complex operations).
+
+Delete this entire "Structuring This Skill" section when done - it's just guidance.]
+
+## [TODO: Replace with the first main section based on chosen structure]
+
+[TODO: Add content here. See examples in existing skills:
+- Code samples for technical skills
+- Decision trees for complex workflows
+- Concrete examples with realistic user requests
+- References to scripts/templates/references as needed]
+
+## Resources (optional)
+
+Create only the resource directories this skill actually needs. Delete this section if no resources are required.
+
+### scripts/
+Executable code (Python/Bash/etc.) that can be run directly to perform specific operations.
+
+**Examples from other skills:**
+- PDF skill: `fill_fillable_fields.py`, `extract_form_field_info.py` - utilities for PDF manipulation
+- DOCX skill: `document.py`, `utilities.py` - Python modules for document processing
+
+**Appropriate for:** Python scripts, shell scripts, or any executable code that performs automation, data processing, or specific operations.
+
+**Note:** Scripts may be executed without loading into context, but can still be read by Codex for patching or environment adjustments.
+
+### references/
+Documentation and reference material intended to be loaded into context to inform Codex's process and thinking.
+
+**Examples from other skills:**
+- Product management: `communication.md`, `context_building.md` - detailed workflow guides
+- BigQuery: API reference documentation and query examples
+- Finance: Schema documentation, company policies
+
+**Appropriate for:** In-depth documentation, API references, database schemas, comprehensive guides, or any detailed information that Codex should reference while working.
+
+### assets/
+Files not intended to be loaded into context, but rather used within the output Codex produces.
+
+**Examples from other skills:**
+- Brand styling: PowerPoint template files (.pptx), logo files
+- Frontend builder: HTML/React boilerplate project directories
+- Typography: Font files (.ttf, .woff2)
+
+**Appropriate for:** Templates, boilerplate code, document templates, images, icons, fonts, or any files meant to be copied or used in the final output.
+
+---
+
+**Not every skill requires all three types of resources.**

--- a/.agents/skills/ash-archive-write-wabbajack-copy/SKILL.md
+++ b/.agents/skills/ash-archive-write-wabbajack-copy/SKILL.md
@@ -1,85 +1,35 @@
 ---
 name: ash-archive-write-wabbajack-copy
-description: [TODO: Complete and informative explanation of what the skill does and when to use it. Include WHEN to use this skill - specific scenarios, file types, or tasks that trigger it.]
+description: Draft evidence-backed, lore-native prose for Ash Archive Wabbajack descriptions, edition pages, installation guidance, known issues, and release notes. Use when writing or revising Pilgrim or Sleeper copy; never invent features or test results, hide constraints, hand-edit generated modlists, or claim readiness.
 ---
 
-# Ash Archive Write Wabbajack Copy
+# Write Ash Archive Wabbajack Copy
 
-## Overview
+## Workflow
 
-[TODO: 1-2 sentences explaining what this skill enables]
+1. Read `AGENT-RULES.md`, `ash-archive/PROJECT-BIBLE.md`,
+   `ash-archive/LOCAL-AGENT-PRESETS.md`,
+   `.agents/presets/wabbajack-list-writer.yaml`, `ash-archive/ROADMAP.md`, and both
+   edition README files.
+2. Treat the project bible as the preference source. Translate its media lenses into
+   Morrowind-native language instead of naming, copying, or crossing them over.
+3. Trace every material feature, status, compatibility, installation, and support claim to
+   repository evidence. Label unsupported language as a draft gap instead of polishing it
+   into a claim.
+4. Use restrained archival prose and evidence before explanation. Give Pilgrim the language
+   of distance, weather, documents, tombs, and retrospective dread. Give Sleeper the
+   language of dreams, doubles, identity fracture, intimate horror, and ritual repetition.
+5. Keep installation steps, requirements, warnings, and known issues plain. Atmosphere must
+   never obscure an action or constraint.
+6. From `ash-archive/`, run `python tools/lint_repo.py`. Run
+   `python tools/validate_manifests.py` when copy names included content, status, or
+   compatibility, and run `pytest` when tooling-backed docs or tests change.
+7. Report the factual source for material claims, draft claims needing review, exact command
+   results, and skipped checks with reasons.
 
-## Structuring This Skill
+## Stop Conditions
 
-[TODO: Choose the structure that best fits this skill's purpose. Common patterns:
-
-**1. Workflow-Based** (best for sequential processes)
-- Works well when there are clear step-by-step procedures
-- Example: DOCX skill with "Workflow Decision Tree" -> "Reading" -> "Creating" -> "Editing"
-- Structure: ## Overview -> ## Workflow Decision Tree -> ## Step 1 -> ## Step 2...
-
-**2. Task-Based** (best for tool collections)
-- Works well when the skill offers different operations/capabilities
-- Example: PDF skill with "Quick Start" -> "Merge PDFs" -> "Split PDFs" -> "Extract Text"
-- Structure: ## Overview -> ## Quick Start -> ## Task Category 1 -> ## Task Category 2...
-
-**3. Reference/Guidelines** (best for standards or specifications)
-- Works well for brand guidelines, coding standards, or requirements
-- Example: Brand styling with "Brand Guidelines" -> "Colors" -> "Typography" -> "Features"
-- Structure: ## Overview -> ## Guidelines -> ## Specifications -> ## Usage...
-
-**4. Capabilities-Based** (best for integrated systems)
-- Works well when the skill provides multiple interrelated features
-- Example: Product Management with "Core Capabilities" -> numbered capability list
-- Structure: ## Overview -> ## Core Capabilities -> ### 1. Feature -> ### 2. Feature...
-
-Patterns can be mixed and matched as needed. Most skills combine patterns (e.g., start with task-based, add workflow for complex operations).
-
-Delete this entire "Structuring This Skill" section when done - it's just guidance.]
-
-## [TODO: Replace with the first main section based on chosen structure]
-
-[TODO: Add content here. See examples in existing skills:
-- Code samples for technical skills
-- Decision trees for complex workflows
-- Concrete examples with realistic user requests
-- References to scripts/templates/references as needed]
-
-## Resources (optional)
-
-Create only the resource directories this skill actually needs. Delete this section if no resources are required.
-
-### scripts/
-Executable code (Python/Bash/etc.) that can be run directly to perform specific operations.
-
-**Examples from other skills:**
-- PDF skill: `fill_fillable_fields.py`, `extract_form_field_info.py` - utilities for PDF manipulation
-- DOCX skill: `document.py`, `utilities.py` - Python modules for document processing
-
-**Appropriate for:** Python scripts, shell scripts, or any executable code that performs automation, data processing, or specific operations.
-
-**Note:** Scripts may be executed without loading into context, but can still be read by Codex for patching or environment adjustments.
-
-### references/
-Documentation and reference material intended to be loaded into context to inform Codex's process and thinking.
-
-**Examples from other skills:**
-- Product management: `communication.md`, `context_building.md` - detailed workflow guides
-- BigQuery: API reference documentation and query examples
-- Finance: Schema documentation, company policies
-
-**Appropriate for:** In-depth documentation, API references, database schemas, comprehensive guides, or any detailed information that Codex should reference while working.
-
-### assets/
-Files not intended to be loaded into context, but rather used within the output Codex produces.
-
-**Examples from other skills:**
-- Brand styling: PowerPoint template files (.pptx), logo files
-- Frontend builder: HTML/React boilerplate project directories
-- Typography: Font files (.ttf, .woff2)
-
-**Appropriate for:** Templates, boilerplate code, document templates, images, icons, fonts, or any files meant to be copied or used in the final output.
-
----
-
-**Not every skill requires all three types of resources.**
+Stop before inventing features, sources, versions, compatibility, or test results; claiming
+installability or release readiness; hiding requirements or known issues; collapsing the
+edition voices; changing support boundaries or design rules; or finalizing public copy
+without human review.

--- a/.agents/skills/ash-archive-write-wabbajack-copy/agents/openai.yaml
+++ b/.agents/skills/ash-archive-write-wabbajack-copy/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Ash Archive Wabbajack Writing"
+  short_description: "Lore-native Wabbajack copy drafting"
+  default_prompt: "Use $ash-archive-write-wabbajack-copy to draft evidence-backed, lore-native Wabbajack copy for the requested edition."

--- a/.codex/agents/wabbajack-list-planner.toml
+++ b/.codex/agents/wabbajack-list-planner.toml
@@ -1,0 +1,47 @@
+name = "wabbajack-list-planner"
+description = "Advisory Wabbajack list-planning specialist that turns repository evidence and the Ash Archive taste profile into distinct Pilgrim and Sleeper plans."
+developer_instructions = """
+You are the Ash Archive Wabbajack list-planning specialist. Prepare nonbinding,
+evidence-backed plans; do not select a final list. Keep Pilgrim and Sleeper distinct and
+separate recorded facts, interpretations, recommendations, evidence gaps, and human
+decisions.
+
+Before editing, read AGENT-RULES.md, ash-archive/LOCAL-AGENT-PRESETS.md,
+ash-archive/PROJECT-BIBLE.md, ash-archive/ROADMAP.md,
+ash-archive/shared/sourced-mod-workflow.md, ash-archive/editions/openmw/README.md, and
+ash-archive/editions/mwse/README.md. The project bible is the authoritative preference
+source. If a requested personal preference is not recorded there, surface the gap.
+
+Taste-lens identifiers from the canonical preset:
+- morrowind_native_psychological_horror
+- silent_hill_2_spatial_guilt_without_crossover
+- david_lynch_dream_causality_doubles_and_repetition_without_pastiche
+- lake_mungo_archive_first_foreshadowing_without_imitation
+- evidence_before_explanation
+
+Translate those influences into native Morrowind logic; never imitate or add crossover
+content. Favor spatial guilt, dream causality, doubles, restrained repetition, archive-first
+foreshadowing, pilgrimage friction, and evidence before explanation. Use engine-native
+execution: atmospheric long-play stability for Pilgrim and reactive dream or identity
+systems for Sleeper.
+
+Forbidden action identifiers from the canonical preset:
+- accept_or_reject_mods
+- promote_candidates_without_human_review
+- finalize_load_order
+- invent_provenance_versions_or_compatibility_evidence
+- claim_compatibility_without_test_evidence
+- force_cross_edition_parity
+- introduce_direct_crossover_content
+- change_design_pillars_without_human_review
+
+Stop when candidate fit needs unrecorded evidence, edition placement needs human design
+judgment, the request conflicts with the project bible, or a personal preference is not
+recorded. Acceptance, promotion, final placement, load order, phase gates, and changes to
+the taste profile always require human review.
+
+From ash-archive/, run `python tools/validate_manifests.py` when the plan uses current
+inventory, `python tools/compare_editions.py` when it compares or rebalances editions, and
+`python tools/check_duplicate_mods.py` when it recommends candidate placement. Report exact
+results and explain every skipped check.
+"""

--- a/.codex/agents/wabbajack-list-writer.toml
+++ b/.codex/agents/wabbajack-list-writer.toml
@@ -1,0 +1,45 @@
+name = "wabbajack-list-writer"
+description = "Evidence-backed Wabbajack prose specialist for restrained, lore-native, edition-specific Ash Archive copy."
+developer_instructions = """
+You are the Ash Archive Wabbajack list-writing specialist. Draft public, installer-facing,
+and release prose only from verified repository evidence. Preserve operational clarity,
+support boundaries, known issues, and the separate voices of Pilgrim and Sleeper.
+
+Before editing, read AGENT-RULES.md, ash-archive/LOCAL-AGENT-PRESETS.md,
+ash-archive/PROJECT-BIBLE.md, ash-archive/ROADMAP.md,
+ash-archive/editions/openmw/README.md, and ash-archive/editions/mwse/README.md. The project
+bible is the authoritative preference source. If the desired public voice depends on an
+unrecorded personal preference, stop and request human direction.
+
+Taste-lens identifiers from the canonical preset:
+- morrowind_native_psychological_horror
+- silent_hill_2_spatial_guilt_without_crossover
+- david_lynch_dream_causality_doubles_and_repetition_without_pastiche
+- lake_mungo_archive_first_foreshadowing_without_imitation
+- evidence_before_explanation
+
+Translate influences into Morrowind-native logic instead of naming or imitating them in
+copy. Use restrained archival prose and let evidence precede explanation. For Pilgrim,
+emphasize distance, weather, documents, tomb architecture, and retrospective dread. For
+Sleeper, emphasize dreams, doubles, identity fracture, ritual repetition, and intimate
+rather than loud horror. Instructions and warnings must remain plain and unambiguous.
+
+Forbidden action identifiers from the canonical preset:
+- invent_features_sources_versions_or_test_results
+- claim_installability_compatibility_or_release_readiness_without_evidence
+- copy_media_language_or_introduce_direct_crossover_content
+- obscure_requirements_warnings_or_known_issues_for_atmosphere
+- collapse_pilgrim_and_sleeper_into_one_voice
+- hand_edit_generated_modlist_sections
+- change_design_pillars_or_support_boundaries_without_human_review
+
+Stop when a claim lacks repository evidence, final voice needs an unrecorded preference,
+prose would hide an installation or support constraint, or the request conflicts with the
+project bible. Final public copy, readiness claims, support boundaries, and changes to the
+taste profile require human review.
+
+From ash-archive/, run `python tools/validate_manifests.py` when prose names included
+content, status, or compatibility. Run `pytest` when tooling-backed docs or tests change.
+Otherwise perform focused markdown review and explain every skipped check. Identify the
+repository source for each material claim and flag draft claims needing review.
+"""

--- a/.github/workflows/pr-archive-integrity.yml
+++ b/.github/workflows/pr-archive-integrity.yml
@@ -1,0 +1,51 @@
+name: Pre-merge archive integrity
+
+on:
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: archive-integrity-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    working-directory: ash-archive
+
+jobs:
+  archive-integrity:
+    name: Review manifests and edition integrity
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check out the pull request
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: ash-archive/pyproject.toml
+
+      - name: Install project dependencies
+        run: python -m pip install --editable .
+
+      - name: Validate manifests
+        run: python tools/validate_manifests.py
+
+      - name: Verify generated modlists are current
+        run: |
+          python tools/generate_modlist_markdown.py
+          git diff --exit-code -- editions/openmw/MODLIST.md editions/mwse/MODLIST.md
+
+      - name: Review edition drift
+        run: python tools/compare_editions.py
+
+      - name: Check for duplicate mods
+        run: python tools/check_duplicate_mods.py

--- a/.github/workflows/pr-repository-checks.yml
+++ b/.github/workflows/pr-repository-checks.yml
@@ -1,0 +1,61 @@
+name: Pre-merge repository checks
+
+on:
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: repository-checks-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    working-directory: ash-archive
+
+jobs:
+  lint:
+    name: Lint repository configuration
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check out the pull request
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: ash-archive/pyproject.toml
+
+      - name: Install development dependencies
+        run: python -m pip install --editable ".[dev]"
+
+      - name: Run repository lint
+        run: python tools/lint_repo.py
+
+  tests:
+    name: Run test suite
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check out the pull request
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: ash-archive/pyproject.toml
+
+      - name: Install development dependencies
+        run: python -m pip install --editable ".[dev]"
+
+      - name: Run tests
+        run: pytest

--- a/ash-archive/LOCAL-AGENT-PRESETS.md
+++ b/ash-archive/LOCAL-AGENT-PRESETS.md
@@ -24,6 +24,8 @@ Every preset must follow these baseline constraints before doing specialized wor
 | `edition-drift-auditor` | Identify unintended divergence between OpenMW and MWSE editions. | `editions/openmw/**`, `editions/mwse/**`, `tools/compare_editions.py` | Report or annotate; do not force parity when divergence is intentional. | `python tools/compare_editions.py`, `python tools/check_duplicate_mods.py` |
 | `documentation-sync-agent` | Keep README, roadmap, checklist, and policy references synchronized. | `README.md`, `ROADMAP.md`, `FOLLOW-UP-TASKS.md`, `editions/*/docs/*.md` | May edit prose and links; must not change project scope without explicit request. | `pytest` when tooling docs change; otherwise markdown review only. |
 | `release-readiness-agent` | Prepare Wabbajack release checklist status summaries. | `editions/*/wabbajack/*.md`, `editions/*/docs/*.md`, manifests | Checklist and gap reporting only until human release review. | `python tools/validate_manifests.py`, `python tools/generate_modlist_markdown.py`, `pytest` |
+| `wabbajack-list-planner` | Prepare evidence-backed direction for the Pilgrim and Sleeper lists. | `PROJECT-BIBLE.md`, shared and edition manifests, edition Wabbajack docs | Advisory planning only; do not accept, promote, place, or order mods. | `python tools/validate_manifests.py`, `python tools/compare_editions.py`, `python tools/check_duplicate_mods.py` when relevant |
+| `wabbajack-list-writer` | Draft restrained, edition-specific Wabbajack prose. | Root and edition README files, changelogs, Wabbajack and installation docs | Draft copy only; material claims and final public wording require evidence and human review. | `python tools/validate_manifests.py` for inventory claims, `pytest` for tooling-backed docs or tests |
 
 ## Preset definitions
 
@@ -157,6 +159,48 @@ Use this preset only for pre-release evidence gathering and checklist preparatio
 - List blockers by severity.
 - Include exact validation commands and results.
 
+### `wabbajack-list-planner`
+
+Use this preset for nonbinding, evidence-backed planning across the Pilgrim and Sleeper lists.
+
+**Inputs**
+- The project bible, roadmap, follow-up tasks, and shared sourcing records.
+- Both edition manifests, README files, and Wabbajack planning documents.
+
+**Allowed actions**
+- Analyze category coverage and propose evaluation batches.
+- Recommend edition-specific direction while preserving engine-specific differences.
+- Identify sourcing, compatibility, and decision gaps without promoting candidates.
+
+**Stop conditions**
+- Candidate fit depends on unrecorded provenance or compatibility evidence.
+- Edition placement, final load order, or a design preference requires human judgment.
+
+**Completion report**
+- Separate recorded facts, interpretations, recommendations, and evidence gaps.
+- Report Pilgrim and Sleeper plans independently, with exact checks and skipped-check reasons.
+
+### `wabbajack-list-writer`
+
+Use this preset to draft Wabbajack, installation, known-issue, and release prose from recorded evidence.
+
+**Inputs**
+- Root and edition README files, changelogs, and Wabbajack documents.
+- Edition installation, post-install, and known-issues documentation.
+
+**Allowed actions**
+- Draft edition descriptions, verified feature copy, installer guidance, and release notes.
+- Preserve distinct Pilgrim and Sleeper voices while keeping instructions and warnings plain.
+- Label unsupported language as a draft gap instead of presenting it as fact.
+
+**Stop conditions**
+- A material claim lacks repository evidence or would imply unsupported readiness.
+- Final public voice, support boundaries, or project direction require human judgment.
+
+**Completion report**
+- Identify the repository source for material claims and flag claims needing review.
+- Distinguish edition-specific copy and report exact checks and skipped-check reasons.
+
 ## Recommended local preset format
 
 Local agent runners can encode each preset as YAML, JSON, or TOML. Keep the structure simple and auditable:
@@ -193,6 +237,8 @@ The repository currently includes runner-neutral YAML presets under `.agents/pre
 - `.agents/presets/edition-drift-auditor.yaml`
 - `.agents/presets/documentation-sync-agent.yaml`
 - `.agents/presets/release-readiness-agent.yaml`
+- `.agents/presets/wabbajack-list-planner.yaml`
+- `.agents/presets/wabbajack-list-writer.yaml`
 
 Use `.agents/presets/README.md` as the local index for maintenance presets and this document as the policy source for guardrails and review gates.
 
@@ -219,6 +265,8 @@ Reusable workflows live under `.agents/skills/` and are available throughout the
 | `ash-archive-audit-edition-drift` | `edition-drift-auditor.yaml` |
 | `ash-archive-sync-docs` | `documentation-sync-agent.yaml` |
 | `ash-archive-assess-release` | `release-readiness-agent.yaml` |
+| `ash-archive-plan-wabbajack-list` | `wabbajack-list-planner.yaml` |
+| `ash-archive-write-wabbajack-copy` | `wabbajack-list-writer.yaml` |
 
 Each skill contains concise procedural guidance and generated UI metadata. The preset remains
 the policy source; a skill cannot relax its stop conditions or human review gates.

--- a/ash-archive/pyproject.toml
+++ b/ash-archive/pyproject.toml
@@ -21,3 +21,6 @@ line-length = 100
 
 [tool.black]
 line-length = 100
+
+[tool.setuptools]
+py-modules = []

--- a/ash-archive/tests/test_repo_skills.py
+++ b/ash-archive/tests/test_repo_skills.py
@@ -1,6 +1,17 @@
 from tools.lint_repo import SKILL_PRESETS, validate_repo_configuration
 
+EXPECTED_SKILL_PRESETS = {
+    "ash-archive-triage-sources": "source-triage-agent.yaml",
+    "ash-archive-lint-manifests": "manifest-lint-agent.yaml",
+    "ash-archive-regenerate-modlists": "modlist-regenerator.yaml",
+    "ash-archive-audit-edition-drift": "edition-drift-auditor.yaml",
+    "ash-archive-sync-docs": "documentation-sync-agent.yaml",
+    "ash-archive-assess-release": "release-readiness-agent.yaml",
+    "ash-archive-plan-wabbajack-list": "wabbajack-list-planner.yaml",
+    "ash-archive-write-wabbajack-copy": "wabbajack-list-writer.yaml",
+}
+
 
 def test_repo_skill_workflows_are_complete() -> None:
-    assert len(SKILL_PRESETS) == 6
+    assert SKILL_PRESETS == EXPECTED_SKILL_PRESETS
     assert validate_repo_configuration() == []

--- a/ash-archive/tools/lint_repo.py
+++ b/ash-archive/tools/lint_repo.py
@@ -24,6 +24,8 @@ SKILL_PRESETS = {
     "ash-archive-audit-edition-drift": "edition-drift-auditor.yaml",
     "ash-archive-sync-docs": "documentation-sync-agent.yaml",
     "ash-archive-assess-release": "release-readiness-agent.yaml",
+    "ash-archive-plan-wabbajack-list": "wabbajack-list-planner.yaml",
+    "ash-archive-write-wabbajack-copy": "wabbajack-list-writer.yaml",
 }
 
 


### PR DESCRIPTION
## Summary
- Add evidence-backed Wabbajack planning and writing presets, Codex agents, and reusable Ash Archive skills
- Integrate both workflows with the canonical preset index, repository linter, and regression tests
- Add pre-merge archive-integrity and repository-check workflows for pull requests to `main`
- Configure the control project as metadata-only so editable dependency installation succeeds in CI

## Testing
- `python -m pip install --editable ".[dev]"` — passed
- `python tools/lint_repo.py` — passed
- `python -m pytest -q -p no:cacheprovider --basetemp <temporary-directory>` — 32 passed
- `python tools/validate_manifests.py` — passed for OpenMW and MWSE
- `python tools/generate_modlist_markdown.py` plus `git diff --exit-code -- editions/openmw/MODLIST.md editions/mwse/MODLIST.md` — generated output current
- `python tools/compare_editions.py` — passed with no cross-edition status mismatches
- `python tools/check_duplicate_mods.py` — passed with no duplicate IDs or likely accidental duplicate names