### PR TITLE
ci: add pre-merge review workflows

### DIFF
--- a/.github/workflows/pr-archive-integrity.yml
+++ b/.github/workflows/pr-archive-integrity.yml
@@ -1,0 +1,51 @@
+name: Pre-merge archive integrity
+
+on:
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: archive-integrity-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    working-directory: ash-archive
+
+jobs:
+  archive-integrity:
+    name: Review manifests and edition integrity
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check out the pull request
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: ash-archive/pyproject.toml
+
+      - name: Install project dependencies
+        run: python -m pip install --editable .
+
+      - name: Validate manifests
+        run: python tools/validate_manifests.py
+
+      - name: Verify generated modlists are current
+        run: |
+          python tools/generate_modlist_markdown.py
+          git diff --exit-code -- editions/openmw/MODLIST.md editions/mwse/MODLIST.md
+
+      - name: Review edition drift
+        run: python tools/compare_editions.py
+
+      - name: Check for duplicate mods
+        run: python tools/check_duplicate_mods.py

--- a/.github/workflows/pr-repository-checks.yml
+++ b/.github/workflows/pr-repository-checks.yml
@@ -1,0 +1,61 @@
+name: Pre-merge repository checks
+
+on:
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: repository-checks-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    working-directory: ash-archive
+
+jobs:
+  lint:
+    name: Lint repository configuration
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check out the pull request
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: ash-archive/pyproject.toml
+
+      - name: Install development dependencies
+        run: python -m pip install --editable ".[dev]"
+
+      - name: Run repository lint
+        run: python tools/lint_repo.py
+
+  tests:
+    name: Run test suite
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check out the pull request
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: ash-archive/pyproject.toml
+
+      - name: Install development dependencies
+        run: python -m pip install --editable ".[dev]"
+
+      - name: Run tests
+        run: python -m pytest

--- a/ash-archive/.gitignore
+++ b/ash-archive/.gitignore
@@ -2,4 +2,5 @@ __pycache__/
 *.pyc
 .pytest_cache/
 .venv/
+*.egg-info/
 *.log

--- a/ash-archive/pyproject.toml
+++ b/ash-archive/pyproject.toml
@@ -14,6 +14,9 @@ dev = [
   "yamllint>=1.35",
 ]
 
+[tool.setuptools]
+packages = []
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 


### PR DESCRIPTION
## Summary

- Add a read-only pre-merge workflow for repository lint and the full test suite.
- Add a separate archive-integrity workflow for manifest validation, generated modlist freshness, edition comparison, and duplicate detection.
- Configure both workflows with least-privilege permissions, per-PR concurrency cancellation, Python dependency caching, and manual dispatch support.
- Declare that this control repository has no distributable Python packages so the existing editable install command succeeds, and ignore its generated egg-info directory.

## Why

PR #34 showed that local validation was not enough to prevent committed conflict markers from reaching review. These workflows turn the repository's documented checks into server-side PR status checks with granular names that maintainers can select as required branch-protection gates.

This PR is stacked on #34 because it depends on the repository lint command and development dependencies added there. Retarget it to `main` after #34 merges.

## Validation

From `ash-archive/`:

- `python -m pip install --editable ".[dev]"`
- `python tools/lint_repo.py`
- `python tools/validate_manifests.py`
- `python tools/generate_modlist_markdown.py` followed by a clean generated-file diff
- `python tools/compare_editions.py`
- `python tools/check_duplicate_mods.py`
- `python -m pytest --basetemp <isolated-temp-dir>` — 32 passed

## Scope

No manifest content, edition policy, compatibility status, or release-readiness claim changed.