### PR TITLE
Synchronize repository documentation and release gates

### DIFF
--- a/AGENT-RULES.md
+++ b/AGENT-RULES.md
@@ -1,45 +1,62 @@
-# AGENT RULES
+# Agent rules
 
-These rules apply to AI assistants (Codex, Copilot, Claude, and similar agents) contributing to this repository.
+These rules apply to Codex, Copilot, Claude, and other AI assistants contributing to Ash Archive.
 
 ## Required workflow
 
-1. Work on a dedicated branch and submit changes through a pull request.
-2. Keep PRs small, focused, and reviewable.
-3. Limit scope to the requested task; do not bundle unrelated feature work.
-4. When uncertain, document uncertainty explicitly instead of guessing.
-5. Run relevant validation commands before opening or updating a PR.
-6. Use `ash-archive/LOCAL-AGENT-PRESETS.md` when configuring or running local agents for recurring automated tasks.
+1. Follow the repository guidance in `AGENTS.md` and read `ash-archive/PROJECT-BIBLE.md` plus the affected edition or shared documentation.
+2. Work on a dedicated branch and submit changes through a pull request.
+3. Keep the task small, focused, and limited to the requested scope.
+4. Select the narrowest applicable preset in `ash-archive/LOCAL-AGENT-PRESETS.md` and matching workflow under `.agents/skills/`.
+5. Treat `.agents/presets/` as canonical policy; `.codex/agents/` and `.agents/skills/` may not relax preset stop conditions or review gates.
+6. Document uncertainty instead of guessing.
+7. Run relevant validation before opening or updating a pull request and report skipped checks with reasons.
+8. Update affected changelogs and status documentation when the repository's capabilities or milestone state changes.
 
-## Repository direction and design constraints
+## Human decisions
+
+AI assistants may gather evidence, prepare drafts, and apply mechanical changes within documented policy. Human review remains required for:
+
+- accepting or rejecting mods;
+- promoting candidates into edition manifests;
+- compatibility and playtesting claims;
+- final load order, patch strategy, and edition-parity decisions;
+- public wording that changes support boundaries;
+- Wabbajack release readiness; and
+- exceptions to the project bible.
+
+Do not use delegation, a different preset, or a different tool to bypass a stop condition.
+
+## Repository direction
 
 1. Preserve the two-edition model:
-   - **Ash Archive: Pilgrim Edition** (OpenMW)
-   - **Ash Archive: Sleeper Edition** (classic Morrowind + MCP + MGE XE + MWSE)
-2. Do not collapse both editions into one shared load order.
-3. Preserve Morrowind-native psychological horror direction.
-4. Preserve the **evidence before explanation** principle.
-5. Do not remove or weaken constraints in `ash-archive/PROJECT-BIBLE.md`.
+   - **Pilgrim Edition** — OpenMW
+   - **Sleeper Edition** — classic Morrowind with MCP, MGE XE, and MWSE
+2. Do not collapse both editions into one shared load order or one undifferentiated voice.
+3. Preserve Morrowind-native psychological horror and the evidence-before-explanation principle.
+4. Do not remove or weaken constraints in `ash-archive/PROJECT-BIBLE.md` without explicit human approval.
+5. Do not imply that the planning repository is an installable or playable release.
 
-## Data integrity and evidence standards
+## Data integrity
 
-1. Do not invent URLs, versions, archive names, or test results.
-2. Do not claim compatibility has been tested unless repository documentation already records that evidence.
-3. Do not mark mods as `accepted` without review notes and compatibility evidence.
-4. Do not delete reasoning from rejected-mod records.
-5. Do not overwrite generated sections manually; use repository generation tools.
-6. Treat YAML `.control.meta` files as internal control metadata; they are not MO2 download sidecar `.meta` files and must not be synthesized.
+1. Do not invent URLs, Nexus IDs, archive names, versions, file sizes, hashes, requirements, licenses, test results, or compatibility evidence.
+2. Do not mark mods as accepted or tested without the review and evidence required by repository policy.
+3. Preserve rejected records and their reasoning.
+4. Treat YAML-formatted `.control.meta` files as internal control metadata, not MO2 download sidecars.
+5. Import native MO2 `.meta` data only from verified source artifacts; do not synthesize it from incomplete inventory data.
+6. Do not hand-edit generated `MODLIST.md` sections; run the generator and inspect its diff.
 
 ## Content boundaries
 
 1. No direct horror-franchise crossover content.
 2. No Skyrimification, anime face replacers, or generic jump-scare design.
 3. Do not add convenience fast travel without explicit design review.
-4. Do not add survival systems without clear configuration and testing notes.
+4. Do not add survival systems without configuration, compatibility, and testing plans.
+5. Do not obscure requirements, warnings, or known limitations for atmosphere.
 
-## Validation commands (run when relevant)
+## Validation
 
-From `ash-archive/`:
+From `ash-archive/`, run the checks relevant to the change:
 
 ```bash
 python tools/lint_repo.py
@@ -47,7 +64,8 @@ python tools/validate_manifests.py
 python tools/generate_modlist_markdown.py
 python tools/compare_editions.py
 python tools/check_duplicate_mods.py
+python tools/summarize_sourced_mods.py
 pytest
 ```
 
-If a command is not run, state why in the PR.
+Pull requests to `main` also run repository and archive-integrity workflows. Passing automation proves structural consistency only; it does not prove in-game compatibility, installability, or release readiness.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,27 +1,45 @@
-# Contributing to TheDreamIsTheDoor / Ash Archive
+# Contributing to Ash Archive
 
-Thank you for contributing.
+Ash Archive is a planning and control repository for two sibling Morrowind Wabbajack editions:
 
-This repository is a planning/control repo for **Ash Archive**, organized under `ash-archive/`, with two sibling editions:
+- **Pilgrim Edition** — OpenMW
+- **Sleeper Edition** — classic Morrowind with MCP, MGE XE, and MWSE
 
-- **Pilgrim Edition** (OpenMW)
-- **Sleeper Edition** (classic Morrowind + MCP + MGE XE + MWSE)
+The project is in Phase 1 sourcing. Keep compatibility, installability, and release claims evidence-based; neither edition is currently a playable release.
 
-The project is scaffold/planning-first. Do not present unverified compatibility claims as tested facts.
+## Required reading
+
+Before editing:
+
+1. Read [AGENT-RULES.md](AGENT-RULES.md) if an AI assistant is involved.
+2. Read [ash-archive/PROJECT-BIBLE.md](ash-archive/PROJECT-BIBLE.md) for design constraints.
+3. Read the relevant edition or shared-subsystem documentation.
+4. For recurring automated work, select the narrowest preset in [ash-archive/LOCAL-AGENT-PRESETS.md](ash-archive/LOCAL-AGENT-PRESETS.md).
+
+## Developer setup
+
+Use Python 3.11 or newer. From `ash-archive/`:
+
+```bash
+python -m pip install --editable ".[dev]"
+```
 
 ## Repository layout
 
-- `ash-archive/editions/openmw/` — Pilgrim edition docs and manifests
-- `ash-archive/editions/mwse/` — Sleeper edition docs and manifests
-- `ash-archive/shared/` — shared categories, design rules, sourcing metadata
-- `ash-archive/tools/` — validation and markdown generation tooling
-- `ash-archive/tests/` — Python tests for tooling and schema checks
-- `ash-archive/PROJECT-BIBLE.md` — core project thesis and non-negotiable design constraints
+- `ash-archive/editions/openmw/` — Pilgrim Edition manifests, generated preview, and docs
+- `ash-archive/editions/mwse/` — Sleeper Edition manifests, generated preview, MO2 planning, and docs
+- `ash-archive/shared/` — categories, sourcing metadata, provenance, and shared policy
+- `ash-archive/tools/` — validation, generation, comparison, and lint tooling
+- `ash-archive/tests/` — schema, tooling, agent, skill, and convention tests
+- `.agents/presets/` — canonical runner-neutral automation policy
+- `.codex/agents/` — project-scoped Codex translations
+- `.agents/skills/` — reusable repository workflows
 
-## Branch naming conventions
+## Branch and commit conventions
 
-Use focused branches with one of these prefixes:
+Use a focused branch with one of these prefixes:
 
+- `agent/`
 - `codex/`
 - `copilot/`
 - `docs/`
@@ -31,35 +49,29 @@ Use focused branches with one of these prefixes:
 - `ci/`
 
 Examples:
-- `docs/update-openmw-install-assumptions`
-- `tooling/manifest-error-improvements`
-- `manifests/mwse-status-transition-notes`
 
-## Commit message style
+- `docs/sync-phase-one-status`
+- `tooling/improve-manifest-errors`
+- `manifests/mwse-evaluation-notes`
 
-Use concise prefix-based commit messages:
-
-- `docs:`
-- `tools:`
-- `manifests:`
-- `shared:`
-- `openmw:`
-- `mwse:`
-- `tests:`
-- `ci:`
-
-Examples:
-- `docs: add governance guidance for PR scope`
-- `tools: improve duplicate detection messaging`
-- `shared: add sourced-mod verification fields`
+Use a concise, descriptive commit message. Prefixes such as `docs:`, `tools:`, `manifests:`, `shared:`, `openmw:`, `mwse:`, `tests:`, and `ci:` are encouraged.
 
 ## Pull request expectations
 
-1. Keep PRs small and reviewable.
-2. Explain **what changed**, **why**, and **what did not change**.
-3. Include edition impact (Shared/OpenMW/MWSE/Tooling/Docs-only).
-4. Include validation results or a clear reason for any skipped checks.
-5. Do not mix unrelated changes in one PR.
+1. Keep the PR focused and reviewable.
+2. Explain what changed, why it changed, and what was deliberately left unchanged.
+3. Identify edition impact: shared, Pilgrim, Sleeper, tooling, automation, or docs-only.
+4. Separate recorded facts from recommendations and unresolved assumptions.
+5. Include exact validation results and explain skipped checks.
+6. Update the appropriate changelog when the change is meaningful to maintainers or future release notes.
+7. Do not combine content promotion, tooling refactors, and unrelated documentation cleanup in one PR.
+
+Pull requests to `main` run two automated workflows:
+
+- Repository checks install development dependencies, lint repository configuration, and run the test suite.
+- Archive-integrity checks validate manifests, verify generated modlists, compare editions, and scan for duplicates.
+
+These checks protect repository consistency; they do not prove game compatibility or release readiness.
 
 ## Validation commands
 
@@ -71,66 +83,43 @@ python tools/validate_manifests.py
 python tools/generate_modlist_markdown.py
 python tools/compare_editions.py
 python tools/check_duplicate_mods.py
+python tools/summarize_sourced_mods.py
 pytest
 ```
 
-Use a subset only when truly scope-limited; state what was run.
+After generating modlists, inspect the diff and confirm that only expected generated sections changed.
 
-## Manifest change expectations
+## Manifest and generated-file rules
 
-Internal control metadata files use the `.meta` extension (commonly `.control.meta`) and remain YAML-structured for project tooling. These are separate from MO2 download sidecar `.meta` files and must not be represented as native sidecars.
+Internal control metadata uses YAML-formatted `.control.meta` files. These are not Mod Organizer 2 download sidecars and must not be represented as native sidecars.
 
 When editing manifests:
 
-1. Keep OpenMW and MWSE as sibling implementations, not forced parity.
+1. Preserve Pilgrim and Sleeper as sibling implementations, not forced copies.
 2. Preserve category integrity against `shared/categories.control.meta`.
-3. Preserve cross-edition status intent and explicit rationale.
-4. Avoid speculative metadata.
-5. Do not mark compatibility as tested without documented evidence.
+3. Preserve explicit cross-edition status and rationale.
+4. Do not invent source, version, archive, hash, requirement, or compatibility data.
+5. Do not mark compatibility as tested without recorded evidence.
+6. Regenerate `MODLIST.md` through the generator; never hand-edit generated sections.
 
-## Mod sourcing expectations
+## Sourced-mod workflow
 
-When updating sourcing records:
+Use [ash-archive/shared/sourced-mod-workflow.md](ash-archive/shared/sourced-mod-workflow.md) when triaging or promoting candidates. Treat `shared/sourced-mods.control.meta` as intake metadata, not an accepted-mod manifest.
 
-1. Record evidence and confidence explicitly.
-2. Distinguish candidate vs accepted status clearly.
-3. Do not invent URLs, archive names, or version identifiers.
-4. Do not mark mods accepted without review/testing notes.
+- Record evidence and confidence explicitly.
+- Distinguish candidate, accepted, rejected, and deferred states.
+- Preserve rejected records and their reasoning.
+- Do not promote a candidate without review and compatibility evidence.
+- Keep multi-package source records synchronized when child archives differ from the parent source version.
 
+## Documentation rules
 
-## Sourced-mod candidate workflow
+- Keep the README, roadmap, follow-up checklist, edition docs, and changelogs aligned.
+- State the current planning phase and avoid implying an installer exists before Phase 4 criteria are met.
+- Label unknown information as `unverified`, `needs-testing`, `planned`, `blocked`, or `TBD` as appropriate.
+- Explain what evidence or test would resolve an uncertainty.
+- Preserve Morrowind-native psychological horror, evidence-before-explanation, and the two-edition model.
 
-Use `ash-archive/shared/sourced-mod-workflow.md` when triaging or promoting sourced candidates.
-Treat `shared/sourced-mods.control.meta` as candidate intake metadata, not an accepted-mod manifest.
+## Design-bible exceptions
 
-## Documentation expectations
-
-1. Keep docs aligned with current repo state (planning/scaffold where applicable).
-2. Avoid language that implies release-ready installer state unless true.
-3. Preserve project horror direction: Morrowind-native, evidence-first, no crossover IP content.
-
-## Documenting uncertainty
-
-When facts are incomplete:
-
-- Use explicit uncertainty wording (for example: "unverified", "needs confirmation", "TBD").
-- Add what evidence is missing and what test/check would confirm it.
-- Never replace unknowns with invented details.
-
-## Handling OpenMW vs MWSE differences
-
-1. Prefer edition-appropriate solutions over artificial parity.
-2. Explain when behavior intentionally differs between editions.
-3. Do not collapse both editions into a shared load order.
-
-## Proposing design-bible exceptions
-
-If a change appears to conflict with `ash-archive/PROJECT-BIBLE.md`:
-
-1. Open a PR with a clearly labeled **Design-Bible Exception Request** section.
-2. Explain the exact rule affected, rationale, alternatives considered, and risk.
-3. Do not merge exception-like changes without human maintainer review.
-
-## Additional agent guidance
-
-AI agents should also follow `AGENT-RULES.md`.
+If a proposal conflicts with `ash-archive/PROJECT-BIBLE.md`, add a clearly labeled **Design-Bible Exception Request** to the PR. Identify the affected rule, rationale, alternatives, and risk. Human maintainer approval is required before merge.

--- a/README.md
+++ b/README.md
@@ -1,131 +1,130 @@
 # Ash Archive
 
-**Ash Archive** is a dual-edition Morrowind Wabbajack modlist built around psychological horror native to Vvardenfell. The project is contained in the [`ash-archive`](ash-archive/) sub-directory and ships as two sibling editions that share aesthetic pillars and narrative logic while using engine-specific techniques.
+**Ash Archive** is a dual-edition Morrowind Wabbajack project built around psychological horror native to Vvardenfell. The repository is a planning and control system for two sibling editions that share a thesis and evaluation standards while using engine-specific implementations.
 
----
-
-## Editions
-
-| Edition | Engine | Tagline |
+| Edition | Engine | Identity |
 |---|---|---|
-| **Ash Archive: Pilgrim Edition** | OpenMW | *The island remembers.* |
-| **Ash Archive: Sleeper Edition** | Classic Morrowind + MCP + MGE XE + MWSE | *The dream notices you.* |
+| **Pilgrim Edition** | OpenMW | Stable, atmospheric, long-play pilgrimage horror — *The island remembers.* |
+| **Sleeper Edition** | Classic Morrowind + MCP + MGE XE + MWSE | Script-heavy, reactive dream horror — *The dream notices you.* |
 
-**Pilgrim Edition** is stable, atmospheric, and long-play-focused. It emphasises weather, distance, documents, tomb architecture, and retrospective dread through environmental pressure.
+## Project status
 
-**Sleeper Edition** is script-heavy and reactive. It uses MWSE to deliver dream contamination, identity fracture, and sleep-state horror through event timing and ritual repetition.
+| Area | Status |
+|---|---|
+| Development phase | **Phase 1 — Sourcing** |
+| Public Wabbajack installer | **Not available** |
+| Playable release | **No** |
+| Final load order and patch plan | **Not defined** |
+| Compatibility evidence | Candidate-level and incomplete; hands-on evaluation remains required |
+| Repository automation | Lint, tests, manifest integrity, generated-output, drift, and duplicate checks run on pull requests to `main` |
 
----
+The checked-in manifests and generated `MODLIST.md` files are planning artifacts. A status such as `planned` or `testing` records control-repository state; it does not mean that a public build has been installed or playtested end to end.
+
+See the [roadmap](ash-archive/ROADMAP.md) and [Phase 1 follow-up checklist](ash-archive/FOLLOW-UP-TASKS.md) for the work that remains.
 
 ## Design pillars
 
 - **The Island Remembers** — Vvardenfell is already haunted by prophecy, reincarnation, and suppressed history.
 - **The Dream is Geological** — dread accumulates in strata, not moments.
-- **Reincarnation is Body Horror** — the Nerevarine arc treated as violation, not triumph.
-- **Dagoth Ur is Intimate, Not Loud** — the antagonist as contamination, not spectacle.
-- **The Tribunal Are the Beautiful Crime Scene** — divinity as cover-up.
+- **Reincarnation is Body Horror** — the Nerevarine arc is treated as violation, not triumph.
+- **Dagoth Ur is Intimate, Not Loud** — the antagonist functions as contamination, not spectacle.
+- **The Tribunal Are the Beautiful Crime Scene** — divinity operates as a cover-up.
 - **Evidence Before Explanation** — logs, notes, shrines, and rumours foreshadow; nothing is explained twice.
 
-Horror emerges from Morrowind's own systems and lore. No horror-franchise crossover content, no generic jump scares, no Skyrimification.
+Horror must emerge from Morrowind's own lore and systems: no horror-franchise crossovers, generic jump scares, or Skyrimification.
 
----
+## What the repository contains
 
-## Current status
+- Schema-backed `.control.meta` manifests for each edition.
+- Shared candidate intake, source-triage, and multi-package provenance records.
+- Generated modlist previews derived from the edition manifests.
+- Validation, comparison, duplicate-detection, generation, and repository-lint tooling.
+- Eight runner-neutral maintenance presets, matching project-scoped Codex agents, and matching reusable repository skills.
+- Pull-request checks for repository configuration, tests, manifest validity, generated-output drift, edition drift, and duplicate entries.
 
-> **Planning and scaffold only.** The list is not yet installable, not yet playable, and does not define a final load order.
+Internal `.control.meta` files contain YAML-formatted control data. They are not Mod Organizer 2 download sidecars. Native MO2 `.meta` files must come from verified source artifacts; see [the metadata distinction](ash-archive/shared/mo2-download-meta-sidecars.md).
 
-See [ROADMAP.md](ash-archive/ROADMAP.md) for the phased plan and [CHANGELOG.md](ash-archive/CHANGELOG.md) for version history.
+## Developer setup
 
----
+Requirements:
 
-## Prerequisites
+- Python 3.11 or newer
+- PyYAML at runtime
+- pytest, ruff, and yamllint for development
 
-- **Python 3.11+**
-- **PyYAML** (runtime dependency)
-- **pytest**, **ruff**, and **yamllint** (development/testing)
-
----
-
-## Setup
-
-From inside `ash-archive/`:
-
-```bash
-# Install runtime and development dependencies
-pip install -e ".[dev]"
-```
-
----
-
-## Repository structure
-
-```
-AshArchive/
-├── .agents/skills/            # Repo-scoped reusable Codex workflows
-├── .codex/agents/             # Repo-scoped Codex agent configurations
-├── ash-archive/              # Main project root
-│   ├── editions/
-│   │   ├── openmw/           # Pilgrim Edition manifests and docs
-│   │   └── mwse/             # Sleeper Edition manifests and docs
-│   ├── shared/               # Categories, design rules, evaluation rubric
-│   ├── tools/                # Python validation and generation scripts
-│   ├── tests/                # Python tests for tooling and schema checks
-│   ├── PROJECT-BIBLE.md      # Full design philosophy and horror translation notes
-│   ├── ROADMAP.md
-│   └── CHANGELOG.md
-├── CONTRIBUTING.md
-└── README.md
-```
-
-Internal control metadata lives in YAML `.control.meta` files used by project tooling and is **not** the same as MO2 download sidecar `.meta` files. See `ash-archive/shared/mo2-download-meta-sidecars.md` for the distinction.
-
----
-
-## Tooling quick start
-
-All commands are run from inside `ash-archive/`.
+From `ash-archive/`:
 
 ```bash
-# Lint Python, YAML, agent TOML, and repo skills
+python -m pip install --editable ".[dev]"
+```
+
+## Validation and generation
+
+Run commands from `ash-archive/`:
+
+```bash
+# Lint Python, YAML control metadata, agent TOML, and repository skills
 python tools/lint_repo.py
 
-# Validate manifests
+# Validate both edition manifests and shared schemas
 python tools/validate_manifests.py
 
-# Generate modlist markdown
+# Regenerate the derived edition modlists
 python tools/generate_modlist_markdown.py
 
-# Compare editions
+# Review intentional and unexplained edition differences
 python tools/compare_editions.py
 
-# Check for duplicate mods across editions
+# Find duplicate IDs and likely accidental duplicate names
 python tools/check_duplicate_mods.py
 
-# Summarise sourced-mod candidates
+# Summarize candidate intake records
 python tools/summarize_sourced_mods.py
 
 # Run the test suite
 pytest
 ```
 
----
+Do not hand-edit generated sections in edition `MODLIST.md` files.
+
+## Repository map
+
+```text
+AshArchive/
+├── .agents/
+│   ├── presets/              # Canonical runner-neutral maintenance policies
+│   └── skills/               # Reusable repository workflows
+├── .codex/agents/            # Runnable project-scoped Codex translations
+├── .github/workflows/        # Pre-merge repository and archive-integrity checks
+├── ash-archive/
+│   ├── editions/
+│   │   ├── openmw/           # Pilgrim Edition manifests and documentation
+│   │   └── mwse/             # Sleeper Edition manifests and documentation
+│   ├── shared/               # Categories, sourcing, provenance, and design rules
+│   ├── tools/                # Validation and generation scripts
+│   ├── tests/                # Tooling, schema, agent, and skill tests
+│   ├── PROJECT-BIBLE.md
+│   ├── ROADMAP.md
+│   ├── FOLLOW-UP-TASKS.md
+│   └── CHANGELOG.md
+├── AGENTS.md
+├── AGENT-RULES.md
+├── CONTRIBUTING.md
+└── README.md
+```
 
 ## Documentation
 
-- [Project Bible](ash-archive/PROJECT-BIBLE.md) — thesis, dual-edition philosophy, horror translation notes, and core atmosphere rules
-- [Roadmap](ash-archive/ROADMAP.md) — development phases from scaffold to Wabbajack release
-- [Pilgrim Edition](ash-archive/editions/openmw/README.md) — OpenMW edition identity and scope
-- [Sleeper Edition](ash-archive/editions/mwse/README.md) — MWSE edition identity and scope
-- [Changelog](ash-archive/CHANGELOG.md)
-- [Local Agent Presets](ash-archive/LOCAL-AGENT-PRESETS.md) — repo-scoped agents and skills for safe maintenance tasks
-
----
-
-## Contributing
-
-See [CONTRIBUTING.md](CONTRIBUTING.md) for branch naming conventions, commit style, PR expectations, validation commands, and guidelines for manifest and mod-sourcing changes.
-
----
+- [Project Bible](ash-archive/PROJECT-BIBLE.md) — thesis, dual-edition philosophy, and non-negotiable atmosphere rules
+- [Roadmap](ash-archive/ROADMAP.md) — phase goals, gates, and current development state
+- [Follow-up Tasks](ash-archive/FOLLOW-UP-TASKS.md) — immediate Phase 1 sourcing and Phase 2 preparation work
+- [Pilgrim Edition](ash-archive/editions/openmw/README.md) — OpenMW identity, artifacts, and documentation
+- [Sleeper Edition](ash-archive/editions/mwse/README.md) — MWSE identity, artifacts, and documentation
+- [Changelog](ash-archive/CHANGELOG.md) — repository-level change history
+- [Local Agent Presets](ash-archive/LOCAL-AGENT-PRESETS.md) — automation scopes, stop conditions, and human-review gates
+- [Contributing](CONTRIBUTING.md) — setup, branch, validation, metadata, and PR conventions
+- [Agent Rules](AGENT-RULES.md) — mandatory rules for automated contributors
+- [Security Policy](SECURITY.md)
 
 ## License
 

--- a/ash-archive/CHANGELOG.md
+++ b/ash-archive/CHANGELOG.md
@@ -1,4 +1,37 @@
 # Changelog
 
-## [0.1.0] - 2026-04-25
-- Initial scaffold and tooling for Ash Archive control repository.
+Repository-level changes are recorded here. Edition-specific planning changes are also summarized in each edition's changelog.
+
+## [Unreleased]
+
+### Added
+
+- Shared sourced-mod candidate intake, validation, summary tooling, and promotion guidance.
+- Initial evidence-backed candidate set for dream/Sixth House, blight/ash/weather, and MWSE survival themes.
+- Source-triage and multi-package provenance records, including explicit promotion blockers and child-package metadata.
+- Mod Organizer 2 planning records for Sleeper Edition.
+- Expanded roadmap and Phase 1 follow-up checklist.
+- Six baseline maintenance presets for source triage, manifest linting, modlist generation, edition drift, documentation sync, and release-readiness assessment.
+- Matching project-scoped Codex agents and reusable repository skills for every canonical preset.
+- Wabbajack list-planning and evidence-backed copywriting presets, agents, and skills, bringing the synchronized automation set to eight workflows.
+- Pull-request workflows for repository lint/tests and archive-integrity checks.
+
+### Changed
+
+- Migrated internal YAML control records to the `.control.meta` filename convention and clarified that they are not MO2 download sidecars.
+- Hardened manifest validation, category and engine rules, duplicate detection, generated-markdown sanitization, and error reporting.
+- Added repository linting for Python, YAML control metadata, agent TOML, skill metadata, and preset/translation consistency.
+- Made generated modlist freshness, edition drift, and duplicate checks part of pre-merge automation.
+- Configured the metadata-only Python project so editable installs work in development and CI.
+- Expanded contributor, agent, status, edition, installation, known-limitations, post-install, and release-gate documentation.
+
+### Fixed
+
+- Reconciled the sourced-candidate schema with its validator and summary tool after parallel changes.
+- Corrected metadata loader terminology and legacy filename-convention tests after the `.control.meta` migration.
+- Fixed editable-install package discovery for the control repository.
+- Strengthened tests so every canonical preset must have a matching Codex agent and repository skill.
+
+## [0.1.0] — 2026-04-25
+
+- Initial Ash Archive dual-edition control repository scaffold.

--- a/ash-archive/FOLLOW-UP-TASKS.md
+++ b/ash-archive/FOLLOW-UP-TASKS.md
@@ -1,10 +1,22 @@
 # Follow-up Tasks
 
-This task list tracks the immediate work needed to finish **Phase 1 - Sourcing** and prepare the project for **Phase 2 - Evaluation**.
+This checklist tracks the immediate work needed to finish **Phase 1 — Sourcing** and prepare Ash Archive for **Phase 2 — Evaluation**.
+
+## Repository maintenance foundation
+
+The control-repository work needed to support the sourcing milestone is complete:
+
+- [x] Standardize internal YAML control metadata on the `.control.meta` filename convention.
+- [x] Add schema, naming, generation, duplicate, drift, and repository-lint checks.
+- [x] Add runner-neutral maintenance presets with matching Codex agents and reusable repository skills.
+- [x] Add pull-request workflows for repository checks and archive integrity.
+- [x] Make editable dependency installation work for the metadata-only control project.
+
+These checks protect repository consistency; they are not substitutes for mod compatibility testing or end-to-end game installation.
 
 ## Milestone target: Phase 1 sourcing exit
 
-Phase 1 is complete when candidate pools are sufficiently populated across major categories for both editions, validation passes cleanly, and all active candidates have provenance plus decision notes.
+Phase 1 is complete when candidate pools cover the major needs of both editions, validation passes cleanly, and every active candidate has provenance, confidence, and decision notes.
 
 ### Source triage gate
 
@@ -17,38 +29,45 @@ Phase 1 is complete when candidate pools are sufficiently populated across major
 ### Candidate intake expansion
 
 - [ ] Expand `shared/sourced-mods.control.meta` beyond the current dream, blight, and survival buckets.
-- [ ] Add candidates for underrepresented major categories in both editions, especially foundation, preservation, architecture, soundscape, UI/journal, and faith/Temple themes.
-- [ ] Record stable kebab-case IDs, source URLs, evidence notes, source confidence, compatibility status, thematic bucket, promotion target, risk level, and engine notes for each new candidate.
-- [ ] Leave compatibility as `unverified` or `needs-testing` unless there is documented test evidence or reliable upstream documentation.
-- [ ] Retain rejected candidates with explicit rejection reasoning instead of deleting them.
+- [ ] Add candidates for underrepresented categories, especially foundation, preservation, architecture, soundscape, UI/journal, and faith/Temple themes.
+- [ ] Record a stable kebab-case ID, source URL, evidence notes, source confidence, compatibility status, thematic bucket, promotion target, risk level, and engine notes for every new candidate.
+- [ ] Leave compatibility as `unverified` or `needs-testing` unless repository evidence supports a stronger state.
+- [ ] Retain rejected candidates with explicit reasoning instead of deleting them.
 
 ### Multi-package source metadata
 
-- [ ] Audit `shared/source-package-meta.control.meta` for multi-package sources that need child package records.
-- [ ] Confirm each package has an install artifact, variant name, edition notes, and plugin list.
-- [ ] Add child `package_version` values when a package differs from the parent `base_version`.
+- [ ] Audit `shared/source-package-meta.control.meta` for sources that require child package records.
+- [ ] Confirm each package has a reproducible install artifact, variant name, edition notes, and plugin list.
+- [ ] Add child `package_version` values when a package differs from its parent `base_version`.
+- [ ] Remove local absolute paths from install-artifact records only after a verified portable archive identity is available.
 - [ ] Keep parent source metadata stable when only one child package version diverges.
 
 ### Phase 2 evaluation preparation
 
 - [ ] Define the first evaluation batches by category and test route.
 - [ ] Start with high-impact horror candidates: Sixth House/dream, blight/ambience, and MWSE survival/body-pressure candidates.
-- [ ] Prepare evaluation notes for compatibility, conflicts, mitigation paths, and edition-specific behavior.
+- [ ] Create a repeatable evidence format for compatibility, conflicts, mitigation, performance, and edition-specific behavior.
 - [ ] Do not promote candidates into edition manifests until human review confirms the evaluation evidence.
 - [ ] Preserve intentional OpenMW/MWSE differences rather than forcing feature parity.
 
 ### Placeholder manifest cleanup
 
-- [ ] Replace `source: "tbd"` and empty source/version/archive fields only when verified provenance exists.
-- [ ] Update patch notes, testing notes, requirements, conflicts, and load-order notes as evaluation evidence becomes available.
+- [ ] Replace `source: "tbd"` and empty source, version, archive, or requirement fields only when verified provenance exists.
+- [ ] Update patch, testing, requirement, conflict, and load-order notes as evaluation evidence becomes available.
 - [ ] Keep placeholder entries marked `planned` until they have enough evidence to advance.
 - [ ] Regenerate modlist markdown after manifest updates.
 
-### Validation checklist
+### Milestone validation
 
-- [ ] Run `python tools/validate_manifests.py` after each metadata batch.
-- [ ] Run `python tools/generate_modlist_markdown.py` after manifest changes.
-- [ ] Run `python tools/compare_editions.py` after cross-edition status changes.
-- [ ] Run `python tools/check_duplicate_mods.py` after adding or renaming candidates.
-- [ ] Run `pytest` before opening milestone-completion PRs.
+Run from `ash-archive/` before proposing Phase 1 completion:
 
+- [ ] `python tools/lint_repo.py`
+- [ ] `python tools/validate_manifests.py`
+- [ ] `python tools/generate_modlist_markdown.py`
+- [ ] Confirm generated modlists have no unexplained diff.
+- [ ] `python tools/compare_editions.py`
+- [ ] `python tools/check_duplicate_mods.py`
+- [ ] `python tools/summarize_sourced_mods.py`
+- [ ] `pytest`
+
+Record the exact results and any skipped check in the milestone pull request.

--- a/ash-archive/README.md
+++ b/ash-archive/README.md
@@ -1,26 +1,60 @@
-# Ash Archive
+# Ash Archive control project
 
-Ash Archive is a control repository for a dual-edition Morrowind Wabbajack project built around Morrowind-native psychological horror design.
+This directory contains the planning, metadata, documentation, and validation tooling for the dual-edition Ash Archive Morrowind Wabbajack project.
 
 ## Editions
-- **Ash Archive: Pilgrim Edition** (OpenMW) — *The island remembers.*
-- **Ash Archive: Sleeper Edition** (classic Morrowind + MCP + MGE XE + MWSE) — *The dream notices you.*
 
-## Current status
-This repository is **planning and scaffold only**. It is not yet a final Wabbajack installer, not yet playable, and does not define a final load order.
+- **Pilgrim Edition** — OpenMW; atmospheric, long-play pilgrimage horror. *The island remembers.*
+- **Sleeper Edition** — classic Morrowind with MCP, MGE XE, and MWSE; reactive dream horror. *The dream notices you.*
 
-## Tooling quick start
-From `ash-archive/`:
+The editions share design pillars and evidence standards, but they do not share a forced load order or artificial feature parity.
 
-- Lint Python and repository configuration:
-  - `python tools/lint_repo.py`
-- Validate manifests:
-  - `python tools/validate_manifests.py`
-- Generate modlist markdown:
-  - `python tools/generate_modlist_markdown.py`
-- Compare editions:
-  - `python tools/compare_editions.py`
-- Check for duplicate mods:
-  - `python tools/check_duplicate_mods.py`
-- Run tests:
-  - `pytest`
+## Current state
+
+The project is in **Phase 1 — Sourcing**. The control repository is operational, but neither edition is an installable or playable release. Manifests contain planned and evaluation-stage records, generated modlists are previews, and end-to-end installation evidence does not yet exist.
+
+Immediate work is tracked in [FOLLOW-UP-TASKS.md](FOLLOW-UP-TASKS.md). Phase gates and release criteria are defined in [ROADMAP.md](ROADMAP.md).
+
+## Setup
+
+From this directory:
+
+```bash
+python -m pip install --editable ".[dev]"
+```
+
+## Common commands
+
+```bash
+python tools/lint_repo.py
+python tools/validate_manifests.py
+python tools/generate_modlist_markdown.py
+python tools/compare_editions.py
+python tools/check_duplicate_mods.py
+python tools/summarize_sourced_mods.py
+pytest
+```
+
+`MODLIST.md` generated sections must be updated through `tools/generate_modlist_markdown.py`, not edited manually.
+
+## Working model
+
+- `editions/openmw/` and `editions/mwse/` hold edition-specific manifests and docs.
+- `shared/` holds categories, candidate intake, source triage, multi-package provenance, and cross-edition policy.
+- `.control.meta` files are YAML-formatted internal metadata, not MO2 download sidecars.
+- `tools/` and `tests/` enforce schemas, naming, derived output, and repository automation consistency.
+- `../.agents/presets/` is the canonical policy layer for recurring automation.
+- `../.codex/agents/` and `../.agents/skills/` provide runnable translations and workflows governed by those presets.
+- Pull requests to `main` run repository and archive-integrity workflows before merge.
+
+## Start here
+
+- [Project Bible](PROJECT-BIBLE.md)
+- [Roadmap](ROADMAP.md)
+- [Follow-up Tasks](FOLLOW-UP-TASKS.md)
+- [Repository Changelog](CHANGELOG.md)
+- [Pilgrim Edition](editions/openmw/README.md)
+- [Sleeper Edition](editions/mwse/README.md)
+- [Local Agent Presets](LOCAL-AGENT-PRESETS.md)
+- [Contributing guide](../CONTRIBUTING.md)
+- [Agent rules](../AGENT-RULES.md)

--- a/ash-archive/ROADMAP.md
+++ b/ash-archive/ROADMAP.md
@@ -1,65 +1,96 @@
 # Roadmap
 
-## Current state (April 2026)
-- Repository foundation is in place: dual-edition structure, schema-backed manifests, baseline docs, and validation/generation tooling.
-- Project remains **planning/scaffold**, not yet an installable or fully playable Wabbajack list.
+## Current state — July 2026
 
-## Phase 0 - Scaffold (completed)
-**Goal:** establish guardrails before content scaling.
+- **Active phase:** Phase 1 — Sourcing.
+- The dual-edition control structure, metadata schemas, generated modlist pipeline, validation tooling, repository lint, agent policy, and pre-merge checks are in place.
+- Shared candidate intake and source-triage records exist, but category coverage, provenance cleanup, and compatibility evaluation remain incomplete.
+- The project is **not** an installable Wabbajack release, has no final load order, and has no end-to-end playtest record.
+
+Immediate Phase 1 work is tracked in [FOLLOW-UP-TASKS.md](FOLLOW-UP-TASKS.md).
+
+## Phase 0 — Scaffold (completed)
+
+**Goal:** establish structure and guardrails before content scaling.
 
 Completed outcomes:
+
 - Shared and per-edition manifest layout defined.
-- Validation and consistency tooling established.
-- Baseline documentation created for setup, policy, and testing flow.
+- Internal metadata standardized on YAML-formatted `.control.meta` files and explicitly separated from MO2 download sidecars.
+- Validation, generation, comparison, duplicate detection, and repository lint tooling established.
+- Baseline project, edition, contributor, sourcing, metadata, and testing documentation created.
+- Runner-neutral maintenance presets, runnable project-scoped Codex agents, and reusable repository skills synchronized under automated tests.
+- Pull-request workflows added for lint, tests, manifest validity, generated-output freshness, edition drift, and duplicate checks.
 
-## Phase 1 - Sourcing (active)
-**Goal:** build trustworthy candidate pools with traceable provenance.
+## Phase 1 — Sourcing (active)
 
-In-scope work:
-- Expand `shared/sourced-mods.control.meta` (.meta extension, YAML-structured content) with verified metadata and source links.
-- Keep triage and package metadata synchronized (`shared/source-triage.control.meta`, `shared/source-package-meta.control.meta`).
-- Track rejected options with retained reasoning.
-
-Exit criteria:
-- Candidate pools are sufficiently populated across major categories for both editions.
-- Validation passes with no structural issues.
-- Source provenance and decision notes are present for all active candidates.
-
-## Phase 2 - Evaluation
-**Goal:** convert sourced candidates into evidence-based accept/reject decisions.
+**Goal:** build trustworthy candidate pools with traceable provenance while preserving edition-specific direction.
 
 In-scope work:
-- Evaluate by category and test route using the shared rubric.
-- Record compatibility notes, conflicts, and mitigation paths.
-- Promote tested entries into edition manifests; document rejections with rationale.
+
+- Expand `shared/sourced-mods.control.meta` across underrepresented major categories.
+- Resolve blockers in `shared/source-triage.control.meta`, including official-plugin policy and unidentified or non-reproducible packages.
+- Keep `shared/source-package-meta.control.meta` synchronized for sources that provide multiple installable packages.
+- Replace placeholder source, version, archive, and requirement fields only when evidence exists.
+- Define initial evaluation batches and test routes without promoting untested candidates.
 
 Exit criteria:
+
+- Candidate pools cover the major categories needed by both editions.
+- Active candidates include source provenance, confidence, decision notes, and an explicit compatibility state.
+- Blocking source-triage questions are resolved or deliberately deferred with recorded rationale.
+- Validation, generated-output, edition-comparison, duplicate, lint, and test checks pass for the milestone branch.
+
+## Phase 2 — Evaluation
+
+**Goal:** convert sourced candidates into evidence-based accept, reject, or defer decisions.
+
+In-scope work:
+
+- Evaluate candidates by category, engine, and test route using the shared rubric.
+- Record compatibility behavior, conflicts, performance considerations, and mitigation paths.
+- Preserve rejected candidates and their reasoning.
+- Promote entries into edition manifests only after human review of recorded evidence.
+
+Exit criteria:
+
 - Core categories have evaluated coverage for both editions.
-- Major conflicts are either resolved or explicitly deferred with notes.
-- Accepted entries include compatibility evidence.
+- Major conflicts are resolved, mitigated, or explicitly deferred.
+- Accepted entries have reproducible source and compatibility evidence.
+- Intentional OpenMW/MWSE differences are documented rather than flattened into parity.
 
-## Phase 3 - Edition hardening
+## Phase 3 — Edition hardening
+
 **Goal:** stabilize each edition as a coherent, testable package.
 
 In-scope work:
-- Lock edition-level load-order policy enforcement.
+
+- Establish and enforce edition-level load-order policy.
 - Finalize patch strategy and external tool requirements.
-- Run repeated validation and checklist cycles for regression control.
+- Replace planning placeholders with verified configuration and support documentation.
+- Run repeated install, route, performance, and regression passes.
 
 Exit criteria:
-- Both editions have internally consistent manifests and patch plans.
-- Known issues are documented with severity and workarounds.
-- Release checklists are actionable and reproducible.
 
-## Phase 4 - Wabbajack release preparation
+- Each edition has internally consistent manifests, load-order policy, and patch plans.
+- Installation and post-install procedures are reproducible.
+- Known issues are documented with severity, affected scope, and workarounds where available.
+- Release checklists are actionable and backed by recorded results.
+
+## Phase 4 — Wabbajack release preparation
+
 **Goal:** ship installable builds with clear support boundaries.
 
 In-scope work:
+
 - Freeze manifests for release candidates.
-- Produce final modlist exports and installer-facing documentation.
-- Perform end-to-end install tests and capture support notes.
+- Build Wabbajack artifacts and final installer-facing documentation.
+- Perform clean-machine end-to-end installation tests for both editions.
+- Publish release notes, known issues, prerequisites, and support expectations.
 
 Exit criteria:
-- Install flow succeeds for each edition using documented steps.
-- Release notes and known issues are published.
-- Versioned release artifacts are ready for distribution.
+
+- Each documented install flow succeeds from a clean environment.
+- Generated artifacts match frozen manifests and verified source metadata.
+- Release notes and known issues are complete.
+- A human maintainer approves each edition for distribution.

--- a/ash-archive/editions/mwse/CHANGELOG.md
+++ b/ash-archive/editions/mwse/CHANGELOG.md
@@ -1,7 +1,23 @@
 # Changelog
 
 ## [Unreleased]
-- Add Mod Organizer 2 as a tracked external tool with initial setup notes.
 
-## [0.1.0] - 2026-04-25
-- Initial edition scaffold.
+### Added
+
+- Mod Organizer 2 as a planned external tool, with initial acquisition, setup, and profile notes.
+- Edition status, artifact index, installation-state, known-limitations, post-install, and release-gate documentation.
+- Sleeper-aware planning, writing, drift-audit, documentation-sync, and release-readiness automation under the shared preset policy.
+
+### Changed
+
+- Migrated edition manifests from legacy YAML filenames to YAML-formatted `.control.meta` records.
+- Kept the generated Sleeper modlist under pre-merge freshness, manifest, drift, and duplicate checks.
+- Clarified that the MO2 scaffold, manifest states, and generated previews do not imply an installable or playtested release.
+
+### Current development note
+
+- Sleeper Edition remains in Phase 1 sourcing with no public installer, production MO2 profile, final load order, patch plan, or end-to-end compatibility record.
+
+## [0.1.0] — 2026-04-25
+
+- Initial Sleeper Edition scaffold.

--- a/ash-archive/editions/mwse/README.md
+++ b/ash-archive/editions/mwse/README.md
@@ -1,21 +1,53 @@
 # Ash Archive: Sleeper Edition
 
-**Engine target:** Classic Morrowind + MCP + MGE XE + MWSE
+**Engine target:** Classic Morrowind + MCP + MGE XE + MWSE  
+**Tagline:** *The dream notices you.*
 
-**Tagline:** The dream notices you.
-
-## Edition identity
-Script-heavy, reactive, psychologically invasive dream horror.
+Sleeper Edition is the script-heavy, reactive branch of Ash Archive. Its horror should emerge through dream contamination, identity fracture, sleep-state pressure, bodily systems, event timing, and ritual repetition.
 
 ## Current status
-Planning/scaffold only. Not installable yet. No final load order is defined.
 
-## What belongs in this edition
-- Mods and tools that reinforce this edition's engine strengths.
-- Atmosphere and systems aligned to Ash Archive design pillars.
-- Entries that are documented with notes and explicit verification status.
+| Area | Status |
+|---|---|
+| Development phase | Phase 1 — Sourcing |
+| Installer | Not available |
+| Playable release | No |
+| Final load order | Not defined |
+| Patch plan | Not defined |
+| MO2 production profile | Not defined |
+| Candidate evaluation | Incomplete |
 
-## What does not belong in this edition
+The manifest and generated modlist are planning artifacts. `planned` and `testing` are repository workflow states, not evidence of a supported public build.
+
+## Current artifacts
+
+- [Control manifest](manifests/mods.control.meta) — planned edition records and evidence fields
+- [External-tool manifest](manifests/external-tools.control.meta) — records Mod Organizer 2 as planned tooling
+- [Generated modlist preview](MODLIST.md) — derived from the manifest; do not edit its generated section manually
+- [Installation status](docs/installation.md) — current requirements and missing install evidence
+- [MO2 setup notes](mod-organizer-2/setup-notes.md) and [profile notes](mod-organizer-2/profile-notes.md) — planning only
+- [Post-install status](docs/post-install.md) — future configuration and verification scope
+- [Known limitations](docs/known-issues.md) — planning-stage gaps, not a runtime bug list
+- [Release checklist](wabbajack/release-checklist.md) — evidence gates that remain before distribution
+- [Changelog](CHANGELOG.md)
+
+## What belongs in Sleeper Edition
+
+- MCP, MGE XE, and MWSE systems supported by recorded source and compatibility evidence.
+- Reactive dreams, sleep-state horror, body pressure, identity instability, and carefully timed intrusion.
+- Script-heavy systems with explicit configuration, conflict, performance, and support notes.
+- Edition-specific choices that use the classic engine stack deliberately rather than imitating OpenMW.
+
+## What does not belong
+
 - Direct crossover content from unrelated horror franchises.
-- Mods that undermine travel design, lore tone, or project stability.
-- Undocumented additions with unknown source or unclear behavior.
+- Generic jump scares or atmosphere-breaking spectacle.
+- Undocumented additions with uncertain source or behavior.
+- Script-heavy features without a test plan and configuration boundaries.
+- Claims of stability or compatibility without hands-on evidence.
+
+## Next milestone
+
+Complete Phase 1 candidate coverage and provenance cleanup, then evaluate Sleeper candidates by category and route. Survival and dream systems require particular scrutiny because of their script, UI, balance, and performance impact. Promotion remains a human-reviewed decision.
+
+See the project [roadmap](../../ROADMAP.md), [follow-up checklist](../../FOLLOW-UP-TASKS.md), and [project bible](../../PROJECT-BIBLE.md).

--- a/ash-archive/editions/mwse/docs/installation.md
+++ b/ash-archive/editions/mwse/docs/installation.md
@@ -1,8 +1,49 @@
-# Installation
+# Installation status — Sleeper Edition
 
-## External tools
+> Sleeper Edition does not yet have a public Wabbajack installer or a supported manual installation procedure.
 
-### Mod Organizer 2
-- Required mod manager for MWSE edition scaffolding.
-- Source: https://github.com/ModOrganizer2/modorganizer
-- Configuration details are pending; see `mod-organizer-2/setup-notes.md`.
+The repository currently contains planning metadata, a generated modlist preview, and preliminary Mod Organizer 2 notes. These are not a complete install recipe or production profile.
+
+## Planned engine and tool stack
+
+- Classic Morrowind
+- Morrowind Code Patch
+- MGE XE
+- MWSE
+- Mod Organizer 2
+
+The exact versions, acquisition paths, configuration, and compatibility constraints remain to be verified and pinned.
+
+## Mod Organizer 2 planning
+
+MO2 is recorded as a planned external tool in [`manifests/external-tools.control.meta`](../manifests/external-tools.control.meta). The current [setup notes](../mod-organizer-2/setup-notes.md) and [profile notes](../mod-organizer-2/profile-notes.md) deliberately avoid claiming a production configuration.
+
+Internal repository `.control.meta` files are not native MO2 download sidecars. Native sidecar data must be imported from verified MO2 artifacts; see the [metadata distinction](../../../shared/mo2-download-meta-sidecars.md).
+
+## Not yet defined
+
+- Supported Morrowind distribution and clean-game baseline
+- Pinned MCP, MGE XE, MWSE, and MO2 versions
+- Verified archive identities and acquisition rules
+- Production MO2 profile and executable configuration
+- Final mod selection and load order
+- Patch and conflict-resolution plan
+- Wabbajack build and clean-machine installation evidence
+- Hardware, storage, and support requirements
+
+## Current developer workflow
+
+Repository contributors can validate the planning data from `ash-archive/`:
+
+```bash
+python tools/validate_manifests.py
+python tools/generate_modlist_markdown.py
+python tools/compare_editions.py
+python tools/check_duplicate_mods.py
+```
+
+These commands validate repository structure only. They do not install or launch Morrowind.
+
+## Publication gate
+
+Installation instructions should be finalized only after Phase 3 produces a reproducible Sleeper configuration and Phase 4 records successful clean-environment Wabbajack installs. Until then, use the [generated modlist](../MODLIST.md) only as a planning preview and consult the [release checklist](../wabbajack/release-checklist.md) for blockers.

--- a/ash-archive/editions/mwse/docs/known-issues.md
+++ b/ash-archive/editions/mwse/docs/known-issues.md
@@ -1,3 +1,20 @@
-# Known Issues
+# Known limitations — Sleeper Edition
 
-Placeholder document for mwse edition.
+This is not yet a runtime bug list. Sleeper Edition has no supported build or production MO2 profile to test. The current known limitations are planning and evidence gaps.
+
+## Release-blocking limitations
+
+- No public Wabbajack installer or reproducible manual installation exists.
+- Candidate coverage and source provenance remain incomplete.
+- Manifest entries marked `planned` or `testing` have not been validated as a complete edition.
+- MCP, MGE XE, MWSE, and MO2 versions and configuration are not pinned.
+- The MO2 setup and profile documents are scaffolds, not production instructions.
+- Final load order, patch strategy, script-conflict policy, and performance budget are not defined.
+- No clean-machine install, dream/sleep route test, scripted-event pass, performance pass, save/reload regression pass, or long-play record exists.
+- Installation, post-install, support, and hardware requirements are not finalized.
+
+## Reporting a repository issue
+
+Repository issues may still be filed for broken links, invalid metadata, stale generated output, schema failures, unexplained edition drift, or duplicate records. Include the affected path and the exact validation command and output when possible.
+
+Do not report a planned manifest entry as a confirmed compatibility bug until a reproducible test environment and result are recorded.

--- a/ash-archive/editions/mwse/docs/post-install.md
+++ b/ash-archive/editions/mwse/docs/post-install.md
@@ -1,3 +1,18 @@
-# Post Install
+# Post-install status — Sleeper Edition
 
-Placeholder document for mwse edition.
+No supported post-install procedure exists because Sleeper Edition has not reached installer or production-profile testing.
+
+When the edition enters hardening, this document must record:
+
+- the pinned MO2 profile, executables, and virtual-file-system expectations;
+- MCP options and the pinned MGE XE/MWSE configuration;
+- required plugin and asset ordering;
+- list-specific graphics, audio, interface, input, dream, and survival settings;
+- first-launch generation or cache steps;
+- a short smoke-test route for startup, dreams, sleep, travel, scripted events, combat, saves, and reloads;
+- expected warnings and how to distinguish them from failures; and
+- the logs and profile files a user should include in a support report.
+
+Every instruction must be tested against a clean Wabbajack installation. Repository validation output alone is not sufficient evidence.
+
+See [installation status](installation.md), [known limitations](known-issues.md), and the [release checklist](../wabbajack/release-checklist.md).

--- a/ash-archive/editions/mwse/wabbajack/release-checklist.md
+++ b/ash-archive/editions/mwse/wabbajack/release-checklist.md
@@ -1,3 +1,45 @@
-# Release Checklist
+# Sleeper Edition release checklist
 
-Scaffold phase only; release items to be defined after validation phase.
+Sleeper Edition remains in Phase 1 sourcing. Checked repository-foundation items do not imply that the edition is installable or release-ready.
+
+## Repository foundation
+
+- [x] Edition directory, manifest schema, and generated modlist pipeline exist.
+- [x] Mod Organizer 2 is recorded as planned external tooling with preliminary setup and profile notes.
+- [x] Manifest, generated-output, drift, duplicate, lint, and test checks are available in pull-request automation.
+- [x] Planning-stage installation, post-install, and known-limitations documents exist.
+
+## Phase 1 — sourcing gate
+
+- [ ] Major category candidate coverage is sufficient for Sleeper Edition.
+- [ ] Active candidates have verified or explicitly qualified provenance.
+- [ ] Source-triage blockers affecting Sleeper are resolved or deliberately deferred.
+- [ ] Multi-package sources have reproducible child-package identities.
+- [ ] Placeholder source, version, archive, and requirement fields are resolved where evidence permits.
+
+## Phase 2 — evaluation gate
+
+- [ ] Initial Sleeper evaluation batches and routes are defined.
+- [ ] Candidate compatibility, script conflicts, performance, balance, and mitigation are recorded.
+- [ ] Dream, sleep, survival, and body-pressure systems have explicit configuration and interaction tests.
+- [ ] Accepted, rejected, and deferred decisions retain evidence and human review.
+- [ ] Intentional differences from Pilgrim Edition are documented.
+
+## Phase 3 — hardening gate
+
+- [ ] MCP, MGE XE, MWSE, and MO2 versions and configuration are pinned.
+- [ ] A production MO2 profile, executable set, final load order, and patch plan are reproducible.
+- [ ] Installation and post-install instructions are tested.
+- [ ] Startup, dream/sleep, travel, scripted-event, combat, save/reload, performance, and long-play routes pass.
+- [ ] Known issues, performance expectations, and support data are documented.
+
+## Phase 4 — release gate
+
+- [ ] A release-candidate manifest and MO2 profile freeze are recorded.
+- [ ] Wabbajack artifact builds from the frozen inputs.
+- [ ] Clean-environment installation succeeds using the public instructions.
+- [ ] Generated artifacts match verified source metadata and the frozen manifest.
+- [ ] Release notes, prerequisites, known issues, and support boundaries are complete.
+- [ ] Human maintainer approves distribution.
+
+Record exact evidence for every completed item. A passing repository check cannot replace an install or playtest result.

--- a/ash-archive/editions/openmw/CHANGELOG.md
+++ b/ash-archive/editions/openmw/CHANGELOG.md
@@ -1,4 +1,22 @@
 # Changelog
 
-## [0.1.0] - 2026-04-25
-- Initial edition scaffold.
+## [Unreleased]
+
+### Added
+
+- Edition status, artifact index, installation-state, known-limitations, post-install, and release-gate documentation.
+- Pilgrim-aware planning, writing, drift-audit, documentation-sync, and release-readiness automation under the shared preset policy.
+
+### Changed
+
+- Migrated edition manifests from legacy YAML filenames to YAML-formatted `.control.meta` records.
+- Kept the generated Pilgrim modlist under pre-merge freshness, manifest, drift, and duplicate checks.
+- Clarified that manifest states and generated previews do not imply an installable or playtested release.
+
+### Current development note
+
+- Pilgrim Edition remains in Phase 1 sourcing with no public installer, final load order, patch plan, or end-to-end compatibility record.
+
+## [0.1.0] — 2026-04-25
+
+- Initial Pilgrim Edition scaffold.

--- a/ash-archive/editions/openmw/README.md
+++ b/ash-archive/editions/openmw/README.md
@@ -1,21 +1,50 @@
 # Ash Archive: Pilgrim Edition
 
-**Engine target:** OpenMW
+**Engine target:** OpenMW  
+**Tagline:** *The island remembers.*
 
-**Tagline:** The island remembers.
-
-## Edition identity
-Stable, atmospheric, long-play-focused pilgrimage horror.
+Pilgrim Edition is the stable, atmospheric, long-play branch of Ash Archive. Its horror should emerge through weather, distance, documents, tomb architecture, pilgrimage, and retrospective dread rather than script-heavy intrusion.
 
 ## Current status
-Planning/scaffold only. Not installable yet. No final load order is defined.
 
-## What belongs in this edition
-- Mods and tools that reinforce this edition's engine strengths.
-- Atmosphere and systems aligned to Ash Archive design pillars.
-- Entries that are documented with notes and explicit verification status.
+| Area | Status |
+|---|---|
+| Development phase | Phase 1 — Sourcing |
+| Installer | Not available |
+| Playable release | No |
+| Final load order | Not defined |
+| Patch plan | Not defined |
+| Candidate evaluation | Incomplete |
 
-## What does not belong in this edition
+The manifest and generated modlist are planning artifacts. `planned` and `testing` are repository workflow states, not evidence of a supported public build.
+
+## Current artifacts
+
+- [Control manifest](manifests/mods.control.meta) — planned edition records and evidence fields
+- [Generated modlist preview](MODLIST.md) — derived from the manifest; do not edit its generated section manually
+- [Installation status](docs/installation.md) — explains why no install procedure is available yet
+- [Post-install status](docs/post-install.md) — future configuration and verification scope
+- [Known limitations](docs/known-issues.md) — planning-stage gaps, not a runtime bug list
+- [Release checklist](wabbajack/release-checklist.md) — evidence gates that remain before distribution
+- [Changelog](CHANGELOG.md)
+
+## What belongs in Pilgrim Edition
+
+- OpenMW-compatible foundations and tools supported by recorded evidence.
+- Environmental pressure, long-distance travel, ash and weather, archives, tombs, and restrained sound design.
+- Systems that remain suitable for long play without flattening Vvardenfell into convenience.
+- Edition-specific choices with explicit source, compatibility, and evaluation notes.
+
+## What does not belong
+
 - Direct crossover content from unrelated horror franchises.
-- Mods that undermine travel design, lore tone, or project stability.
-- Undocumented additions with unknown source or unclear behavior.
+- Generic jump scares or atmosphere-breaking spectacle.
+- Undocumented additions with uncertain source or behavior.
+- Features selected only to mimic Sleeper Edition when OpenMW calls for a different solution.
+- Claims of stability or compatibility without hands-on evidence.
+
+## Next milestone
+
+Complete Phase 1 candidate coverage and provenance cleanup, then evaluate Pilgrim candidates by category and route. Promotion into the edition manifest remains a human-reviewed decision.
+
+See the project [roadmap](../../ROADMAP.md), [follow-up checklist](../../FOLLOW-UP-TASKS.md), and [project bible](../../PROJECT-BIBLE.md).

--- a/ash-archive/editions/openmw/docs/installation.md
+++ b/ash-archive/editions/openmw/docs/installation.md
@@ -1,3 +1,32 @@
-# Installation
+# Installation status — Pilgrim Edition
 
-Placeholder document for openmw edition.
+> Pilgrim Edition does not yet have a public Wabbajack installer or a supported manual installation procedure.
+
+The repository currently contains planning metadata and a generated modlist preview. Those files are inputs to sourcing and evaluation; they are not a complete install recipe and should not be treated as one.
+
+## Not yet defined
+
+- Supported Morrowind distribution and clean-game baseline
+- Pinned OpenMW version and configuration
+- Verified archive identities and acquisition rules
+- Final mod selection and load order
+- Patch and conflict-resolution plan
+- Wabbajack build and clean-machine installation evidence
+- Hardware, storage, and support requirements
+
+## Current developer workflow
+
+Repository contributors can validate the planning data from `ash-archive/`:
+
+```bash
+python tools/validate_manifests.py
+python tools/generate_modlist_markdown.py
+python tools/compare_editions.py
+python tools/check_duplicate_mods.py
+```
+
+These commands validate repository structure only. They do not install or launch Morrowind.
+
+## Publication gate
+
+Installation instructions should be written only after Phase 3 produces a reproducible Pilgrim configuration and Phase 4 records successful clean-environment Wabbajack installs. Until then, use the [generated modlist](../MODLIST.md) only as a planning preview and consult the [release checklist](../wabbajack/release-checklist.md) for blockers.

--- a/ash-archive/editions/openmw/docs/known-issues.md
+++ b/ash-archive/editions/openmw/docs/known-issues.md
@@ -1,3 +1,18 @@
-# Known Issues
+# Known limitations — Pilgrim Edition
 
-Placeholder document for openmw edition.
+This is not yet a runtime bug list. Pilgrim Edition has no supported build to test. The current known limitations are planning and evidence gaps.
+
+## Release-blocking limitations
+
+- No public Wabbajack installer or reproducible manual installation exists.
+- Candidate coverage and source provenance remain incomplete.
+- Manifest entries marked `planned` or `testing` have not been validated as a complete edition.
+- OpenMW version, configuration, final load order, and patch strategy are not pinned.
+- No clean-machine install, route test, performance pass, save/reload regression pass, or long-play record exists.
+- Installation, post-install, support, and hardware requirements are not finalized.
+
+## Reporting a repository issue
+
+Repository issues may still be filed for broken links, invalid metadata, stale generated output, schema failures, unexplained edition drift, or duplicate records. Include the affected path and the exact validation command and output when possible.
+
+Do not report a planned manifest entry as a confirmed compatibility bug until a reproducible test environment and result are recorded.

--- a/ash-archive/editions/openmw/docs/post-install.md
+++ b/ash-archive/editions/openmw/docs/post-install.md
@@ -1,3 +1,17 @@
-# Post Install
+# Post-install status — Pilgrim Edition
 
-Placeholder document for openmw edition.
+No supported post-install procedure exists because Pilgrim Edition has not reached installer testing.
+
+When the edition enters hardening, this document must record:
+
+- the pinned OpenMW executable and configuration path;
+- required content-file and data-directory ordering;
+- list-specific graphics, audio, interface, and input settings;
+- first-launch shader or cache behavior where applicable;
+- a short smoke-test route for startup, travel, weather, interiors, combat, saves, and reloads;
+- expected warnings and how to distinguish them from failures; and
+- the files a user should include in a support report.
+
+Every instruction must be tested against a clean Wabbajack installation. Repository validation output alone is not sufficient evidence.
+
+See [installation status](installation.md), [known limitations](known-issues.md), and the [release checklist](../wabbajack/release-checklist.md).

--- a/ash-archive/editions/openmw/wabbajack/release-checklist.md
+++ b/ash-archive/editions/openmw/wabbajack/release-checklist.md
@@ -1,3 +1,43 @@
-# Release Checklist
+# Pilgrim Edition release checklist
 
-Scaffold phase only; release items to be defined after validation phase.
+Pilgrim Edition remains in Phase 1 sourcing. Checked repository-foundation items do not imply that the edition is installable or release-ready.
+
+## Repository foundation
+
+- [x] Edition directory, manifest schema, and generated modlist pipeline exist.
+- [x] Manifest, generated-output, drift, duplicate, lint, and test checks are available in pull-request automation.
+- [x] Planning-stage installation, post-install, and known-limitations documents exist.
+
+## Phase 1 — sourcing gate
+
+- [ ] Major category candidate coverage is sufficient for Pilgrim Edition.
+- [ ] Active candidates have verified or explicitly qualified provenance.
+- [ ] Source-triage blockers affecting Pilgrim are resolved or deliberately deferred.
+- [ ] Multi-package sources have reproducible child-package identities.
+- [ ] Placeholder source, version, archive, and requirement fields are resolved where evidence permits.
+
+## Phase 2 — evaluation gate
+
+- [ ] Initial Pilgrim evaluation batches and routes are defined.
+- [ ] Candidate compatibility, conflicts, performance, and mitigation are recorded.
+- [ ] Accepted, rejected, and deferred decisions retain evidence and human review.
+- [ ] Intentional differences from Sleeper Edition are documented.
+
+## Phase 3 — hardening gate
+
+- [ ] OpenMW version and configuration are pinned.
+- [ ] Final mod selection, load order, and patch plan are reproducible.
+- [ ] Installation and post-install instructions are tested.
+- [ ] Startup, travel, weather, interior, combat, save/reload, and long-play routes pass.
+- [ ] Known issues, performance expectations, and support data are documented.
+
+## Phase 4 — release gate
+
+- [ ] A release-candidate manifest freeze is recorded.
+- [ ] Wabbajack artifact builds from the frozen inputs.
+- [ ] Clean-environment installation succeeds using the public instructions.
+- [ ] Generated artifacts match verified source metadata and the frozen manifest.
+- [ ] Release notes, prerequisites, known issues, and support boundaries are complete.
+- [ ] Human maintainer approves distribution.
+
+Record exact evidence for every completed item. A passing repository check cannot replace an install or playtest result.


### PR DESCRIPTION
## Summary

- synchronize the root and control-project READMEs with the current Phase 1 sourcing state
- document the eight preset/agent/skill workflows and the two pull-request validation workflows added in recent merges
- expand the repository and edition changelogs to cover sourcing, metadata, tooling, automation, and MO2 planning work
- replace skeletal edition installation, post-install, known-issues, and release pages with explicit status and evidence gates
- align the roadmap, follow-up checklist, contributing guide, and agent rules with the live repository

## Why

The documentation still described an early April scaffold even though the repository now has source-triage data, generated modlist checks, runnable agents and skills, and pre-merge automation. The old wording also did not consistently distinguish structurally valid planning metadata from an installable or playtested modlist.

## User and maintainer impact

The updated docs make the current boundary unambiguous: Ash Archive is in Phase 1 sourcing, neither edition is publicly installable or playable, and repository automation is not compatibility evidence. Maintainers now have concrete Phase 1, evaluation, hardening, and release gates for both editions.

## Scope

Documentation only. No manifests, candidate states, generated modlists, Python tooling, tests, workflows, or game files were changed.

## Validation

- compared `agent/sync-repository-documentation` with `main`: 1 commit, 19 documentation files, no unrelated paths
- checked all relative links introduced by the edited pages against the live repository paths
- confirmed the branch is based on current `main` at `5c312b2034c43ae275962cb3fb0ecac754c4a5ca`
- repository and archive-integrity workflows will provide the authoritative automated results on this PR

## Review notes

Please review the public status language and the release-gate wording in particular. The PR deliberately makes no new compatibility, installability, or release-readiness claims.