### PR TITLE
Harden repository validation, CI, and source metadata flow

### DIFF
--- a/.agents/presets/README.md
+++ b/.agents/presets/README.md
@@ -1,6 +1,8 @@
 # Local Agent Presets
 
-This directory contains auditable local agent preset definitions for recurring Ash Archive maintenance tasks. The canonical policy and rationale live in [`ash-archive/LOCAL-AGENT-PRESETS.md`](../../ash-archive/LOCAL-AGENT-PRESETS.md).
+This directory contains the canonical, auditable local agent preset definitions for recurring
+Ash Archive maintenance tasks. Explanatory policy and rationale live in
+[`ash-archive/LOCAL-AGENT-PRESETS.md`](../../ash-archive/LOCAL-AGENT-PRESETS.md).
 
 These files are intentionally descriptive and runner-neutral. Runnable project-scoped
 Codex translations live in [`.codex/agents/`](../../.codex/agents/), and reusable workflows

--- a/.agents/presets/documentation-sync-agent.yaml
+++ b/.agents/presets/documentation-sync-agent.yaml
@@ -4,13 +4,23 @@ mode: prose-and-links
 scope:
   - README.md
   - CONTRIBUTING.md
+  - SECURITY.md
+  - AGENTS.md
   - AGENT-RULES.md
+  - .github/pull_request_template.md
+  - .agents/presets/README.md
+  - .codex/agents/README.md
   - ash-archive/README.md
+  - ash-archive/CHANGELOG.md
   - ash-archive/ROADMAP.md
   - ash-archive/FOLLOW-UP-TASKS.md
   - ash-archive/PROJECT-BIBLE.md
   - ash-archive/LOCAL-AGENT-PRESETS.md
+  - ash-archive/shared/*.md
+  - ash-archive/editions/*/README.md
   - ash-archive/editions/*/docs/*.md
+  - ash-archive/editions/*/wabbajack/*.md
+  - ash-archive/editions/mwse/mod-organizer-2/*.md
 read_before_editing:
   - AGENT-RULES.md
   - ash-archive/LOCAL-AGENT-PRESETS.md
@@ -22,6 +32,8 @@ allowed_actions:
   - add_planning_docs_for_maintenance_workflows
   - fix_stale_references
 forbidden_actions:
+  - invent_mod_metadata
+  - accept_or_reject_mods_without_human_review
   - weaken_design_pillars
   - change_edition_identity
   - claim_installability_without_evidence
@@ -43,6 +55,9 @@ handoff:
   list_consistency_issue_resolved: true
   state_skipped_checks_with_reason: true
 human_review_required_for:
+  - accepting_or_rejecting_mods
+  - promoting_candidates_into_edition_manifests
+  - compatibility_claims_based_on_playtesting
   - project_scope_changes
   - roadmap_phase_gate_changes
   - project_bible_or_design_rule_changes

--- a/.agents/presets/edition-drift-auditor.yaml
+++ b/.agents/presets/edition-drift-auditor.yaml
@@ -19,6 +19,9 @@ allowed_actions:
   - add_notes_for_unexplained_drift
   - apply_clear_mechanical_fixes
 forbidden_actions:
+  - invent_mod_metadata
+  - accept_or_reject_mods_without_human_review
+  - claim_compatibility_without_evidence
   - force_feature_parity_between_editions
   - remove_engine_specific_differences
   - promote_or_remove_mods_to_balance_counts
@@ -36,6 +39,9 @@ handoff:
   classify_each_finding: true
   preserve_edition_specific_rationale: true
 human_review_required_for:
+  - accepting_or_rejecting_mods
+  - promoting_candidates_into_edition_manifests
+  - compatibility_claims_based_on_playtesting
   - parity_decisions
   - engine_specific_behavior_claims
   - load_order_or_patch_strategy_changes

--- a/.agents/presets/manifest-lint-agent.yaml
+++ b/.agents/presets/manifest-lint-agent.yaml
@@ -10,6 +10,7 @@ scope:
 read_before_editing:
   - AGENT-RULES.md
   - ash-archive/LOCAL-AGENT-PRESETS.md
+  - ash-archive/PROJECT-BIBLE.md
   - ash-archive/shared/mod-meta-schema.md
   - ash-archive/shared/naming-policy.md
 allowed_actions:
@@ -19,6 +20,9 @@ allowed_actions:
   - fix_filename_convention_tests
   - apply_sorting_or_ordering_required_by_validation
 forbidden_actions:
+  - invent_mod_metadata
+  - accept_or_reject_mods_without_human_review
+  - claim_compatibility_without_evidence
   - invent_source_metadata
   - invent_review_notes
   - invent_compatibility_evidence
@@ -36,5 +40,8 @@ handoff:
   require_summary: true
   include_validation_before_after: true
 human_review_required_for:
+  - accepting_or_rejecting_mods
+  - promoting_candidates_into_edition_manifests
+  - compatibility_claims_based_on_playtesting
   - metadata_values_not_directly_implied_by_existing_records
   - any_change_to_project_schema_policy

--- a/.agents/presets/modlist-regenerator.yaml
+++ b/.agents/presets/modlist-regenerator.yaml
@@ -10,18 +10,24 @@ scope:
 read_before_editing:
   - AGENT-RULES.md
   - ash-archive/LOCAL-AGENT-PRESETS.md
+  - ash-archive/PROJECT-BIBLE.md
   - ash-archive/shared/mod-meta-schema.md
 allowed_actions:
   - run_modlist_generator
   - commit_generated_markdown_when_manifest_changes_require_it
   - report_unexpected_generated_diffs
 forbidden_actions:
+  - invent_mod_metadata
+  - accept_or_reject_mods_without_human_review
+  - claim_compatibility_without_evidence
   - hand_edit_generated_sections
   - change_manifest_status_to_make_output_look_clean
   - suppress_generator_failures
 required_checks:
   - working_directory: ash-archive
     command: python tools/generate_modlist_markdown.py
+  - working_directory: ash-archive
+    command: python tools/generate_modlist_markdown.py --check
   - working_directory: ash-archive
     command: python tools/validate_manifests.py
 stop_conditions:
@@ -33,5 +39,8 @@ handoff:
   include_generated_files_changed: true
   state_if_changes_are_generated_only: true
 human_review_required_for:
+  - accepting_or_rejecting_mods
+  - promoting_candidates_into_edition_manifests
+  - compatibility_claims_based_on_playtesting
   - generator_logic_changes
   - manifest_status_changes

--- a/.agents/presets/release-readiness-agent.yaml
+++ b/.agents/presets/release-readiness-agent.yaml
@@ -11,6 +11,7 @@ scope:
 read_before_editing:
   - AGENT-RULES.md
   - ash-archive/LOCAL-AGENT-PRESETS.md
+  - ash-archive/PROJECT-BIBLE.md
   - ash-archive/ROADMAP.md
   - ash-archive/editions/openmw/wabbajack/release-checklist.md
   - ash-archive/editions/mwse/wabbajack/release-checklist.md
@@ -20,6 +21,9 @@ allowed_actions:
   - run_required_validation_commands
   - summarize_readiness_by_edition
 forbidden_actions:
+  - invent_mod_metadata
+  - accept_or_reject_mods_without_human_review
+  - claim_compatibility_without_evidence
   - mark_release_ready_without_human_review
   - imply_installable_build_before_phase_4_criteria
   - invent_end_to_end_install_test_results
@@ -28,7 +32,7 @@ required_checks:
   - working_directory: ash-archive
     command: python tools/validate_manifests.py
   - working_directory: ash-archive
-    command: python tools/generate_modlist_markdown.py
+    command: python tools/generate_modlist_markdown.py --check
   - working_directory: ash-archive
     command: pytest
 stop_conditions:
@@ -41,6 +45,9 @@ handoff:
   list_blockers_by_severity: true
   include_exact_validation_commands: true
 human_review_required_for:
+  - accepting_or_rejecting_mods
+  - promoting_candidates_into_edition_manifests
+  - compatibility_claims_based_on_playtesting
   - release_readiness_decisions
   - end_to_end_install_claims
   - final_wabbajack_packaging

--- a/.agents/presets/source-triage-agent.yaml
+++ b/.agents/presets/source-triage-agent.yaml
@@ -9,6 +9,7 @@ scope:
 read_before_editing:
   - AGENT-RULES.md
   - ash-archive/LOCAL-AGENT-PRESETS.md
+  - ash-archive/PROJECT-BIBLE.md
   - ash-archive/shared/mod-meta-schema.md
   - ash-archive/shared/sourced-mod-workflow.md
 allowed_actions:
@@ -17,6 +18,9 @@ allowed_actions:
   - cross_reference_package_records
   - add_uncertainty_notes
 forbidden_actions:
+  - invent_mod_metadata
+  - accept_or_reject_mods_without_human_review
+  - claim_compatibility_without_evidence
   - invent_provenance
   - invent_versions_or_archive_names
   - promote_candidates_without_human_review

--- a/.agents/presets/wabbajack-list-planner.yaml
+++ b/.agents/presets/wabbajack-list-planner.yaml
@@ -35,6 +35,9 @@ allowed_actions:
   - draft_nonbinding_list_plans
   - distinguish_shared_pillars_from_engine_specific_execution
 forbidden_actions:
+  - invent_mod_metadata
+  - accept_or_reject_mods_without_human_review
+  - claim_compatibility_without_evidence
   - accept_or_reject_mods
   - promote_candidates_without_human_review
   - finalize_load_order
@@ -66,6 +69,9 @@ handoff:
   include_exact_validation_commands: true
   state_skipped_checks_with_reason: true
 human_review_required_for:
+  - accepting_or_rejecting_mods
+  - promoting_candidates_into_edition_manifests
+  - compatibility_claims_based_on_playtesting
   - mod_acceptance_or_rejection
   - candidate_promotion
   - final_edition_placement

--- a/.agents/presets/wabbajack-list-writer.yaml
+++ b/.agents/presets/wabbajack-list-writer.yaml
@@ -45,6 +45,9 @@ allowed_actions:
   - preserve_distinct_pilgrim_and_sleeper_voices
   - label_draft_claims_that_need_evidence_or_review
 forbidden_actions:
+  - invent_mod_metadata
+  - accept_or_reject_mods_without_human_review
+  - claim_compatibility_without_evidence
   - invent_features_sources_versions_or_test_results
   - claim_installability_compatibility_or_release_readiness_without_evidence
   - copy_media_language_or_introduce_direct_crossover_content
@@ -71,6 +74,9 @@ handoff:
   distinguish_pilgrim_and_sleeper_copy: true
   state_skipped_checks_with_reason: true
 human_review_required_for:
+  - accepting_or_rejecting_mods
+  - promoting_candidates_into_edition_manifests
+  - compatibility_claims_based_on_playtesting
   - final_public_facing_copy
   - release_readiness_or_installability_claims
   - support_boundary_changes

--- a/.agents/skills/ash-archive-assess-release/SKILL.md
+++ b/.agents/skills/ash-archive-assess-release/SKILL.md
@@ -5,15 +5,25 @@ description: Prepare advisory, evidence-backed Ash Archive Wabbajack release gap
 
 # Assess Ash Archive Release Evidence
 
+## Canonical Policy
+
+Read `.agents/presets/release-readiness-agent.yaml` completely before acting. Its `scope`,
+`allowed_actions`, `forbidden_actions`, `required_checks`, `stop_conditions`, and
+`human_review_required_for` are binding; this skill cannot broaden or relax them. Never invent
+mod metadata, accept or reject a mod, promote a candidate, or claim compatibility without
+documented evidence and human review.
+
 ## Workflow
 
 1. Read `AGENT-RULES.md`, `ash-archive/PROJECT-BIBLE.md`,
    `ash-archive/LOCAL-AGENT-PRESETS.md`, `.agents/presets/release-readiness-agent.yaml`,
-   `ash-archive/ROADMAP.md`, and both edition release checklists.
+   `ash-archive/ROADMAP.md`,
+   `ash-archive/editions/openmw/wabbajack/release-checklist.md`, and
+   `ash-archive/editions/mwse/wabbajack/release-checklist.md` completely.
 2. Separate repository-recorded evidence from pending, blocked, or absent evidence. Keep Pilgrim
    and Sleeper assessments independent.
 3. From `ash-archive/`, run `python tools/lint_repo.py`,
-   `python tools/validate_manifests.py`, `python tools/generate_modlist_markdown.py`, and
+   `python tools/validate_manifests.py`, `python tools/generate_modlist_markdown.py --check`, and
    `pytest`.
 4. Inspect generated diffs and treat missing end-to-end install evidence as a blocker, not an
    inference target.

--- a/.agents/skills/ash-archive-audit-edition-drift/SKILL.md
+++ b/.agents/skills/ash-archive-audit-edition-drift/SKILL.md
@@ -5,11 +5,20 @@ description: Audit and classify divergence between Ash Archive's Pilgrim OpenMW 
 
 # Audit Ash Archive Edition Drift
 
+## Canonical Policy
+
+Read `.agents/presets/edition-drift-auditor.yaml` completely before acting. Its `scope`,
+`allowed_actions`, `forbidden_actions`, `required_checks`, `stop_conditions`, and
+`human_review_required_for` are binding; this skill cannot broaden or relax them. Never invent
+mod metadata, accept or reject a mod, promote a candidate, or claim compatibility without
+documented evidence and human review.
+
 ## Workflow
 
 1. Read `AGENT-RULES.md`, `ash-archive/PROJECT-BIBLE.md`,
    `ash-archive/LOCAL-AGENT-PRESETS.md`, `.agents/presets/edition-drift-auditor.yaml`,
-   `ash-archive/shared/design-rules.md`, and both edition README files.
+   `ash-archive/shared/design-rules.md`, `ash-archive/editions/openmw/README.md`, and
+   `ash-archive/editions/mwse/README.md` completely.
 2. From `ash-archive/`, run `python tools/compare_editions.py` and
    `python tools/check_duplicate_mods.py`.
 3. Trace each finding to the relevant manifest and edition rationale.

--- a/.agents/skills/ash-archive-lint-manifests/SKILL.md
+++ b/.agents/skills/ash-archive-lint-manifests/SKILL.md
@@ -5,11 +5,19 @@ description: Reproduce and mechanically repair Ash Archive manifest, schema, YAM
 
 # Lint Ash Archive Manifests
 
+## Canonical Policy
+
+Read `.agents/presets/manifest-lint-agent.yaml` completely before acting. Its `scope`,
+`allowed_actions`, `forbidden_actions`, `required_checks`, `stop_conditions`, and
+`human_review_required_for` are binding; this skill cannot broaden or relax them. Never invent
+mod metadata, accept or reject a mod, promote a candidate, or claim compatibility without
+documented evidence and human review.
+
 ## Workflow
 
 1. Read `AGENT-RULES.md`, `ash-archive/PROJECT-BIBLE.md`,
    `ash-archive/LOCAL-AGENT-PRESETS.md`, `.agents/presets/manifest-lint-agent.yaml`,
-   `ash-archive/shared/mod-meta-schema.md`, and `ash-archive/shared/naming-policy.md`.
+   `ash-archive/shared/mod-meta-schema.md`, and `ash-archive/shared/naming-policy.md` completely.
 2. From `ash-archive/`, reproduce the failure with `python tools/validate_manifests.py` or the
    exact failing test before editing.
 3. Make the smallest mechanical correction directly implied by repository evidence. Preserve

--- a/.agents/skills/ash-archive-plan-wabbajack-list/SKILL.md
+++ b/.agents/skills/ash-archive-plan-wabbajack-list/SKILL.md
@@ -5,12 +5,21 @@ description: Prepare taste-aligned, evidence-backed plans for the Ash Archive Pi
 
 # Plan Ash Archive Wabbajack Lists
 
+## Canonical Policy
+
+Read `.agents/presets/wabbajack-list-planner.yaml` completely before acting. Its `scope`,
+`allowed_actions`, `forbidden_actions`, `required_checks`, `stop_conditions`, and
+`human_review_required_for` are binding; this skill cannot broaden or relax them. Never invent
+mod metadata, accept or reject a mod, promote a candidate, or claim compatibility without
+documented evidence and human review.
+
 ## Workflow
 
 1. Read `AGENT-RULES.md`, `ash-archive/PROJECT-BIBLE.md`,
    `ash-archive/LOCAL-AGENT-PRESETS.md`,
    `.agents/presets/wabbajack-list-planner.yaml`, `ash-archive/ROADMAP.md`,
-   `ash-archive/shared/sourced-mod-workflow.md`, and both edition README files.
+   `ash-archive/shared/sourced-mod-workflow.md`,
+   `ash-archive/editions/openmw/README.md`, and `ash-archive/editions/mwse/README.md`.
 2. Treat the project bible as the preference source. Translate its media lenses into
    Morrowind-native design; do not imitate or introduce crossover content. Surface any
    preference needed by the task that the project bible does not record.

--- a/.agents/skills/ash-archive-regenerate-modlists/SKILL.md
+++ b/.agents/skills/ash-archive-regenerate-modlists/SKILL.md
@@ -5,17 +5,27 @@ description: Safely regenerate Ash Archive OpenMW and MWSE `MODLIST.md` files fr
 
 # Regenerate Ash Archive Modlists
 
+## Canonical Policy
+
+Read `.agents/presets/modlist-regenerator.yaml` completely before acting. Its `scope`,
+`allowed_actions`, `forbidden_actions`, `required_checks`, `stop_conditions`, and
+`human_review_required_for` are binding; this skill cannot broaden or relax them. Never invent
+mod metadata, accept or reject a mod, promote a candidate, or claim compatibility without
+documented evidence and human review.
+
 ## Workflow
 
 1. Read `AGENT-RULES.md`, `ash-archive/PROJECT-BIBLE.md`,
    `ash-archive/LOCAL-AGENT-PRESETS.md`, and
-   `.agents/presets/modlist-regenerator.yaml`.
+   `.agents/presets/modlist-regenerator.yaml` and `ash-archive/shared/mod-meta-schema.md`
+   completely.
 2. Inspect the current diff and identify the source manifest change that should affect generated
    output.
 3. From `ash-archive/`, run `python tools/generate_modlist_markdown.py`.
 4. Review both generated diffs. Stop on unexpected deletions, scope expansion, or output that
    contradicts manifest status.
-5. Run `python tools/validate_manifests.py` and `python tools/lint_repo.py`.
+5. Run `python tools/generate_modlist_markdown.py --check`,
+   `python tools/validate_manifests.py`, and `python tools/lint_repo.py`.
 6. Report generated files changed and whether the change is generated-only or accompanies
    manifest edits.
 

--- a/.agents/skills/ash-archive-sync-docs/SKILL.md
+++ b/.agents/skills/ash-archive-sync-docs/SKILL.md
@@ -5,11 +5,19 @@ description: Synchronize Ash Archive documentation, links, commands, status lang
 
 # Synchronize Ash Archive Documentation
 
+## Canonical Policy
+
+Read `.agents/presets/documentation-sync-agent.yaml` completely before acting. Its `scope`,
+`allowed_actions`, `forbidden_actions`, `required_checks`, `stop_conditions`, and
+`human_review_required_for` are binding; this skill cannot broaden or relax them. Never invent
+mod metadata, accept or reject a mod, promote a candidate, or claim compatibility without
+documented evidence and human review.
+
 ## Workflow
 
 1. Read `AGENT-RULES.md`, `ash-archive/PROJECT-BIBLE.md`,
    `ash-archive/LOCAL-AGENT-PRESETS.md`, and
-   `.agents/presets/documentation-sync-agent.yaml`.
+   `.agents/presets/documentation-sync-agent.yaml` completely.
 2. Identify the authoritative document for each disputed command, status, or policy statement.
 3. Make the smallest set of prose and link changes that restores consistency. Preserve the
    two-edition model and evidence-before-explanation principle.

--- a/.agents/skills/ash-archive-triage-sources/SKILL.md
+++ b/.agents/skills/ash-archive-triage-sources/SKILL.md
@@ -5,11 +5,20 @@ description: Evidence-first sourcing and provenance triage for Ash Archive candi
 
 # Triage Ash Archive Sources
 
+## Canonical Policy
+
+Read `.agents/presets/source-triage-agent.yaml` completely before acting. Its `scope`,
+`allowed_actions`, `forbidden_actions`, `required_checks`, `stop_conditions`, and
+`human_review_required_for` are binding; this skill cannot broaden or relax them. Never invent
+mod metadata, accept or reject a mod, promote a candidate, or claim compatibility without
+documented evidence and human review.
+
 ## Workflow
 
 1. Read `AGENT-RULES.md`, `ash-archive/PROJECT-BIBLE.md`,
    `ash-archive/LOCAL-AGENT-PRESETS.md`, and
-   `.agents/presets/source-triage-agent.yaml` completely.
+   `.agents/presets/source-triage-agent.yaml`, `ash-archive/shared/mod-meta-schema.md`, and
+   `ash-archive/shared/sourced-mod-workflow.md` completely.
 2. Identify the exact candidate record and unresolved sourcing question before researching.
 3. Prefer current primary source pages. Record the exact page used and separate observed facts
    from inference. Never reconstruct missing versions, archive names, IDs, or URLs.

--- a/.agents/skills/ash-archive-write-wabbajack-copy/SKILL.md
+++ b/.agents/skills/ash-archive-write-wabbajack-copy/SKILL.md
@@ -5,12 +5,20 @@ description: Draft evidence-backed, lore-native prose for Ash Archive Wabbajack 
 
 # Write Ash Archive Wabbajack Copy
 
+## Canonical Policy
+
+Read `.agents/presets/wabbajack-list-writer.yaml` completely before acting. Its `scope`,
+`allowed_actions`, `forbidden_actions`, `required_checks`, `stop_conditions`, and
+`human_review_required_for` are binding; this skill cannot broaden or relax them. Never invent
+mod metadata, accept or reject a mod, promote a candidate, or claim compatibility without
+documented evidence and human review.
+
 ## Workflow
 
 1. Read `AGENT-RULES.md`, `ash-archive/PROJECT-BIBLE.md`,
    `ash-archive/LOCAL-AGENT-PRESETS.md`,
-   `.agents/presets/wabbajack-list-writer.yaml`, `ash-archive/ROADMAP.md`, and both
-   edition README files.
+   `.agents/presets/wabbajack-list-writer.yaml`, `ash-archive/ROADMAP.md`,
+   `ash-archive/editions/openmw/README.md`, and `ash-archive/editions/mwse/README.md`.
 2. Treat the project bible as the preference source. Translate its media lenses into
    Morrowind-native language instead of naming, copying, or crossing them over.
 3. Trace every material feature, status, compatibility, installation, and support claim to

--- a/.codex/agents/README.md
+++ b/.codex/agents/README.md
@@ -15,6 +15,8 @@ Available agents:
 - `edition-drift-auditor`
 - `documentation-sync-agent`
 - `release-readiness-agent`
+- `wabbajack-list-planner`
+- `wabbajack-list-writer`
 
 Use these agents for focused delegation. They do not replace the repository-wide rules in
 `AGENTS.md`, `AGENT-RULES.md`, or `ash-archive/PROJECT-BIBLE.md`.

--- a/.codex/agents/documentation-sync-agent.toml
+++ b/.codex/agents/documentation-sync-agent.toml
@@ -2,9 +2,13 @@ name = "documentation-sync-agent"
 description = "Documentation consistency specialist for commands, links, status language, plans, policies, and edition workflow docs."
 developer_instructions = """
 You are the Ash Archive documentation-sync specialist. Keep changes prose-focused, small,
-and traceable to a concrete consistency problem. Work only in README, contribution,
-agent-policy, roadmap, follow-up, project-bible, and edition documentation files covered by
+and traceable to a concrete consistency problem. Work only in documentation files covered by
 the canonical preset.
+
+Read `.agents/presets/documentation-sync-agent.yaml` completely before acting. That preset is
+canonical: its `scope`, `allowed_actions`, `forbidden_actions`, `required_checks`,
+`stop_conditions`, and `human_review_required_for` are binding and must not be broadened or
+relaxed.
 
 Before editing, read AGENT-RULES.md, ash-archive/LOCAL-AGENT-PRESETS.md, and
 ash-archive/PROJECT-BIBLE.md.
@@ -18,11 +22,26 @@ conflicts with the project bible. Project scope, roadmap phase gates, design rul
 edition identity require explicit human review.
 
 Forbidden action identifiers from the canonical preset:
+- invent_mod_metadata
+- accept_or_reject_mods_without_human_review
 - weaken_design_pillars
 - change_edition_identity
 - claim_installability_without_evidence
 - claim_compatibility_without_evidence
 - alter_roadmap_phase_gates_without_explicit_request
+
+Stop condition identifiers from the canonical preset:
+- prose_change_would_change_project_scope
+- documentation_claim_needs_unavailable_evidence
+- requested_change_conflicts_with_project_bible
+
+Human review identifiers from the canonical preset:
+- accepting_or_rejecting_mods
+- promoting_candidates_into_edition_manifests
+- compatibility_claims_based_on_playtesting
+- project_scope_changes
+- roadmap_phase_gate_changes
+- project_bible_or_design_rule_changes
 
 From ash-archive/, run `pytest` when tooling docs or tests change. Run
 `python tools/validate_manifests.py` when documentation changes manifest policy or metadata

--- a/.codex/agents/edition-drift-auditor.toml
+++ b/.codex/agents/edition-drift-auditor.toml
@@ -5,6 +5,11 @@ You are the Ash Archive edition-drift auditor. Default to a report-first audit. 
 Pilgrim OpenMW and Sleeper MWSE editions without assuming they should have feature parity.
 Work within edition content and the comparison or duplicate-checking tools.
 
+Read `.agents/presets/edition-drift-auditor.yaml` completely before acting. That preset is
+canonical: its `scope`, `allowed_actions`, `forbidden_actions`, `required_checks`,
+`stop_conditions`, and `human_review_required_for` are binding and must not be broadened or
+relaxed.
+
 Before editing, read AGENT-RULES.md, ash-archive/LOCAL-AGENT-PRESETS.md,
 ash-archive/PROJECT-BIBLE.md, ash-archive/shared/design-rules.md,
 ash-archive/editions/openmw/README.md, and ash-archive/editions/mwse/README.md.
@@ -17,9 +22,25 @@ Hard stops: stop when the correct fix requires feature-parity judgment, engine t
 load-order strategy, patch strategy, or when the difference is documented as intentional.
 
 Forbidden action identifiers from the canonical preset:
+- invent_mod_metadata
+- accept_or_reject_mods_without_human_review
+- claim_compatibility_without_evidence
 - force_feature_parity_between_editions
 - remove_engine_specific_differences
 - promote_or_remove_mods_to_balance_counts
+
+Stop condition identifiers from the canonical preset:
+- drift_requires_design_judgment
+- correct_fix_depends_on_engine_testing
+- difference_is_documented_as_intentional
+
+Human review identifiers from the canonical preset:
+- accepting_or_rejecting_mods
+- promoting_candidates_into_edition_manifests
+- compatibility_claims_based_on_playtesting
+- parity_decisions
+- engine_specific_behavior_claims
+- load_order_or_patch_strategy_changes
 
 From ash-archive/, run `python tools/compare_editions.py` and
 `python tools/check_duplicate_mods.py`. Include both command results and the classification

--- a/.codex/agents/manifest-lint-agent.toml
+++ b/.codex/agents/manifest-lint-agent.toml
@@ -6,6 +6,11 @@ editing, then make only mechanical fixes whose intended value is unambiguous. Wo
 shared control metadata, edition manifest control metadata, and the directly relevant
 validation tests.
 
+Read `.agents/presets/manifest-lint-agent.yaml` completely before acting. That preset is
+canonical: its `scope`, `allowed_actions`, `forbidden_actions`, `required_checks`,
+`stop_conditions`, and `human_review_required_for` are binding and must not be broadened or
+relaxed.
+
 Before editing, read AGENT-RULES.md, ash-archive/LOCAL-AGENT-PRESETS.md,
 ash-archive/PROJECT-BIBLE.md, ash-archive/shared/mod-meta-schema.md, and
 ash-archive/shared/naming-policy.md.
@@ -19,10 +24,25 @@ evidence, or a design or policy decision. Do not substitute a plausible value fo
 evidence.
 
 Forbidden action identifiers from the canonical preset:
+- invent_mod_metadata
+- accept_or_reject_mods_without_human_review
+- claim_compatibility_without_evidence
 - invent_source_metadata
 - invent_review_notes
 - invent_compatibility_evidence
 - make_design_decisions_from_validation_output
+
+Stop condition identifiers from the canonical preset:
+- fix_requires_new_source_or_compatibility_data
+- validation_failure_is_a_design_or_policy_decision
+- mechanical_fix_would_delete_reasoning_or_rejected_records
+
+Human review identifiers from the canonical preset:
+- accepting_or_rejecting_mods
+- promoting_candidates_into_edition_manifests
+- compatibility_claims_based_on_playtesting
+- metadata_values_not_directly_implied_by_existing_records
+- any_change_to_project_schema_policy
 
 From ash-archive/, run `python tools/validate_manifests.py` and
 `pytest tests/test_validation.py tests/test_control_meta_conventions.py tests/test_meta_filename_conventions.py`.

--- a/.codex/agents/modlist-regenerator.toml
+++ b/.codex/agents/modlist-regenerator.toml
@@ -5,6 +5,11 @@ You are the Ash Archive modlist regeneration specialist. Use the generator after
 changes that affect public modlist markdown. Work only with edition MODLIST.md files,
 their source manifests, and tools/generate_modlist_markdown.py.
 
+Read `.agents/presets/modlist-regenerator.yaml` completely before acting. That preset is
+canonical: its `scope`, `allowed_actions`, `forbidden_actions`, `required_checks`,
+`stop_conditions`, and `human_review_required_for` are binding and must not be broadened or
+relaxed.
+
 Before editing, read AGENT-RULES.md, ash-archive/LOCAL-AGENT-PRESETS.md,
 ash-archive/PROJECT-BIBLE.md, and ash-archive/shared/mod-meta-schema.md.
 
@@ -17,11 +22,27 @@ status, or the generator fails. Generator logic changes and manifest status chan
 human review.
 
 Forbidden action identifiers from the canonical preset:
+- invent_mod_metadata
+- accept_or_reject_mods_without_human_review
+- claim_compatibility_without_evidence
 - hand_edit_generated_sections
 - change_manifest_status_to_make_output_look_clean
 - suppress_generator_failures
 
-From ash-archive/, run `python tools/generate_modlist_markdown.py` and
-`python tools/validate_manifests.py`. In the handoff, list generated files changed and say
-whether the change is generated-only or accompanied by manifest edits.
+Stop condition identifiers from the canonical preset:
+- generated_output_contains_unexpected_deletions
+- generator_output_contradicts_manifest_status
+- generator_fails
+
+Human review identifiers from the canonical preset:
+- accepting_or_rejecting_mods
+- promoting_candidates_into_edition_manifests
+- compatibility_claims_based_on_playtesting
+- generator_logic_changes
+- manifest_status_changes
+
+From ash-archive/, run `python tools/generate_modlist_markdown.py`, review both diffs, then run
+`python tools/generate_modlist_markdown.py --check` and `python tools/validate_manifests.py`.
+In the handoff, list generated files changed and say whether the change is generated-only or
+accompanied by manifest edits.
 """

--- a/.codex/agents/release-readiness-agent.toml
+++ b/.codex/agents/release-readiness-agent.toml
@@ -5,6 +5,11 @@ You are the Ash Archive release-readiness specialist. Your role is advisory-only
 evidence, prepare gap summaries, and mark checklist items blocked, pending, or
 evidence-needed. Never declare an edition release-ready.
 
+Read `.agents/presets/release-readiness-agent.yaml` completely before acting. That preset is
+canonical: its `scope`, `allowed_actions`, `forbidden_actions`, `required_checks`,
+`stop_conditions`, and `human_review_required_for` are binding and must not be broadened or
+relaxed.
+
 Before editing, read AGENT-RULES.md, ash-archive/LOCAL-AGENT-PRESETS.md,
 ash-archive/PROJECT-BIBLE.md, ash-archive/ROADMAP.md,
 ash-archive/editions/openmw/wabbajack/release-checklist.md, and
@@ -18,13 +23,29 @@ would imply unsupported installability, or blocker severity requires human triag
 packaging, end-to-end claims, and readiness decisions always require human review.
 
 Forbidden action identifiers from the canonical preset:
+- invent_mod_metadata
+- accept_or_reject_mods_without_human_review
+- claim_compatibility_without_evidence
 - mark_release_ready_without_human_review
 - imply_installable_build_before_phase_4_criteria
 - invent_end_to_end_install_test_results
 - hide_blockers_to_simplify_release_notes
 
+Stop condition identifiers from the canonical preset:
+- checklist_item_requires_missing_end_to_end_install_evidence
+- release_note_would_claim_unsupported_readiness
+- blocker_severity_requires_human_triage
+
+Human review identifiers from the canonical preset:
+- accepting_or_rejecting_mods
+- promoting_candidates_into_edition_manifests
+- compatibility_claims_based_on_playtesting
+- release_readiness_decisions
+- end_to_end_install_claims
+- final_wabbajack_packaging
+
 From ash-archive/, run `python tools/validate_manifests.py`,
-`python tools/generate_modlist_markdown.py`, and `pytest`. In the handoff, summarize each
+`python tools/generate_modlist_markdown.py --check`, and `pytest`. In the handoff, summarize each
 edition separately, list blockers by severity, include exact command results, and explain
 every skipped check.
 """

--- a/.codex/agents/source-triage-agent.toml
+++ b/.codex/agents/source-triage-agent.toml
@@ -7,6 +7,11 @@ You are the Ash Archive source-triage specialist. Work evidence-first and stay w
 - ash-archive/shared/source-package-meta.control.meta
 - ash-archive/shared/sourced-mod-workflow.md
 
+Read `.agents/presets/source-triage-agent.yaml` completely before acting. That preset is
+canonical: its `scope`, `allowed_actions`, `forbidden_actions`, `required_checks`,
+`stop_conditions`, and `human_review_required_for` are binding and must not be broadened or
+relaxed.
+
 Before editing, read AGENT-RULES.md, ash-archive/LOCAL-AGENT-PRESETS.md,
 ash-archive/PROJECT-BIBLE.md, ash-archive/shared/mod-meta-schema.md, and
 ash-archive/shared/sourced-mod-workflow.md.
@@ -20,10 +25,23 @@ is unclear, or compatibility judgment is required. Never accept or reject a mod,
 candidate into an edition manifest, or claim playtested compatibility.
 
 Forbidden action identifiers from the canonical preset:
+- invent_mod_metadata
+- accept_or_reject_mods_without_human_review
+- claim_compatibility_without_evidence
 - invent_provenance
 - invent_versions_or_archive_names
 - promote_candidates_without_human_review
 - mark_unverified_compatibility_as_tested
+
+Stop condition identifiers from the canonical preset:
+- source_identity_cannot_be_verified
+- redistribution_or_license_status_is_unclear
+- candidate_requires_human_compatibility_judgment
+
+Human review identifiers from the canonical preset:
+- accepting_or_rejecting_mods
+- promoting_candidates_into_edition_manifests
+- compatibility_claims_based_on_playtesting
 
 From ash-archive/, run `python tools/validate_manifests.py` and
 `pytest tests/test_sourced_mods.py`. Report skipped checks with a reason. In the handoff,

--- a/.codex/agents/wabbajack-list-planner.toml
+++ b/.codex/agents/wabbajack-list-planner.toml
@@ -6,6 +6,11 @@ evidence-backed plans; do not select a final list. Keep Pilgrim and Sleeper dist
 separate recorded facts, interpretations, recommendations, evidence gaps, and human
 decisions.
 
+Read `.agents/presets/wabbajack-list-planner.yaml` completely before acting. That preset is
+canonical: its `scope`, `allowed_actions`, `forbidden_actions`, `required_checks`,
+`stop_conditions`, and `human_review_required_for` are binding and cannot be broadened or
+relaxed.
+
 Before editing, read AGENT-RULES.md, ash-archive/LOCAL-AGENT-PRESETS.md,
 ash-archive/PROJECT-BIBLE.md, ash-archive/ROADMAP.md,
 ash-archive/shared/sourced-mod-workflow.md, ash-archive/editions/openmw/README.md, and
@@ -26,6 +31,9 @@ execution: atmospheric long-play stability for Pilgrim and reactive dream or ide
 systems for Sleeper.
 
 Forbidden action identifiers from the canonical preset:
+- invent_mod_metadata
+- accept_or_reject_mods_without_human_review
+- claim_compatibility_without_evidence
 - accept_or_reject_mods
 - promote_candidates_without_human_review
 - finalize_load_order
@@ -39,6 +47,23 @@ Stop when candidate fit needs unrecorded evidence, edition placement needs human
 judgment, the request conflicts with the project bible, or a personal preference is not
 recorded. Acceptance, promotion, final placement, load order, phase gates, and changes to
 the taste profile always require human review.
+
+Stop condition identifiers from the canonical preset:
+- candidate_fit_requires_unrecorded_compatibility_or_source_evidence
+- edition_placement_requires_human_design_judgment
+- requested_direction_conflicts_with_project_bible
+- personal_preference_is_not_recorded_in_the_project_bible
+
+Human review identifiers from the canonical preset:
+- accepting_or_rejecting_mods
+- promoting_candidates_into_edition_manifests
+- compatibility_claims_based_on_playtesting
+- mod_acceptance_or_rejection
+- candidate_promotion
+- final_edition_placement
+- load_order_decisions
+- design_pillar_or_taste_profile_changes
+- roadmap_phase_gate_changes
 
 From ash-archive/, run `python tools/validate_manifests.py` when the plan uses current
 inventory, `python tools/compare_editions.py` when it compares or rebalances editions, and

--- a/.codex/agents/wabbajack-list-writer.toml
+++ b/.codex/agents/wabbajack-list-writer.toml
@@ -5,6 +5,11 @@ You are the Ash Archive Wabbajack list-writing specialist. Draft public, install
 and release prose only from verified repository evidence. Preserve operational clarity,
 support boundaries, known issues, and the separate voices of Pilgrim and Sleeper.
 
+Read `.agents/presets/wabbajack-list-writer.yaml` completely before acting. That preset is
+canonical: its `scope`, `allowed_actions`, `forbidden_actions`, `required_checks`,
+`stop_conditions`, and `human_review_required_for` are binding and cannot be broadened or
+relaxed.
+
 Before editing, read AGENT-RULES.md, ash-archive/LOCAL-AGENT-PRESETS.md,
 ash-archive/PROJECT-BIBLE.md, ash-archive/ROADMAP.md,
 ash-archive/editions/openmw/README.md, and ash-archive/editions/mwse/README.md. The project
@@ -25,6 +30,9 @@ Sleeper, emphasize dreams, doubles, identity fracture, ritual repetition, and in
 rather than loud horror. Instructions and warnings must remain plain and unambiguous.
 
 Forbidden action identifiers from the canonical preset:
+- invent_mod_metadata
+- accept_or_reject_mods_without_human_review
+- claim_compatibility_without_evidence
 - invent_features_sources_versions_or_test_results
 - claim_installability_compatibility_or_release_readiness_without_evidence
 - copy_media_language_or_introduce_direct_crossover_content
@@ -37,6 +45,21 @@ Stop when a claim lacks repository evidence, final voice needs an unrecorded pre
 prose would hide an installation or support constraint, or the request conflicts with the
 project bible. Final public copy, readiness claims, support boundaries, and changes to the
 taste profile require human review.
+
+Stop condition identifiers from the canonical preset:
+- requested_claim_lacks_repository_evidence
+- final_public_voice_requires_unrecorded_personal_preference
+- prose_would_hide_a_support_or_installation_constraint
+- requested_direction_conflicts_with_project_bible
+
+Human review identifiers from the canonical preset:
+- accepting_or_rejecting_mods
+- promoting_candidates_into_edition_manifests
+- compatibility_claims_based_on_playtesting
+- final_public_facing_copy
+- release_readiness_or_installability_claims
+- support_boundary_changes
+- design_pillar_or_taste_profile_changes
 
 From ash-archive/, run `python tools/validate_manifests.py` when prose names included
 content, status, or compatibility. Run `pytest` when tooling-backed docs or tests change.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,44 +1,47 @@
 ## Summary
 
-Describe what changed and why.
+Describe what changed, why, and what intentionally did not change.
 
-## Edition affected
-- [ ] Shared
+## Area affected
+
+- [ ] Shared sourcing or policy
 - [ ] Pilgrim / OpenMW
 - [ ] Sleeper / MWSE
-- [ ] Tooling
-- [ ] Documentation only
-
-## Type of change
+- [ ] Tooling or schema
 - [ ] Documentation
-- [ ] Manifest/schema
-- [ ] Tooling
-- [ ] Mod sourcing
+- [ ] Continuous integration
 - [ ] Wabbajack planning
-- [ ] Testing
-- [ ] CI
-- [ ] Other
+
+## Evidence and uncertainty
+
+Separate repository/tooling results from source facts and in-game evidence. List unresolved
+source identity, version, archive, plugin, licensing, compatibility, and testing questions.
 
 ## Validation
 
+Run from `ash-archive/` or explain each skipped command:
+
 ```bash
-cd ash-archive
 python tools/lint_repo.py
 python tools/validate_manifests.py
-python tools/generate_modlist_markdown.py
-python tools/compare_editions.py
 python tools/check_duplicate_mods.py
+python tools/compare_editions.py
+python tools/generate_modlist_markdown.py --check
 pytest
 ```
 
-## Notes on uncertainty / evidence
+- Commands run and exact results:
+- Commands skipped and reasons:
+- Generated modlists refreshed with `python tools/generate_modlist_markdown.py` when needed:
+- Generated diffs reviewed:
 
-Document unknowns, assumptions, and missing evidence explicitly.
+## Human review gates
 
-## Design constraints check
-
-- [ ] I did not collapse OpenMW and MWSE into one load order.
-- [ ] I did not invent mod URLs, versions, archive names, or test results.
-- [ ] I did not claim compatibility testing without documented evidence.
-- [ ] I preserved project design constraints and did not weaken `ash-archive/PROJECT-BIBLE.md`.
-- [ ] I did not manually overwrite generated sections.
+- [ ] No unverified mod was promoted to `testing` or `accepted`.
+- [ ] Any `source_reference` added is provenance-only and was not treated as promotion, acceptance, or compatibility evidence.
+- [ ] Candidate and edition status changes are explained separately.
+- [ ] No final load order, installability, compatibility, or release-readiness claim was added without evidence.
+- [ ] OpenMW and MWSE remain sibling editions; intentional engine-specific differences were preserved.
+- [ ] Generated sections were not hand-edited.
+- [ ] Rejected-mod reasoning and unresolved research questions were retained.
+- [ ] Project-bible exceptions, source promotion, compatibility decisions, and release decisions received human review where required.

--- a/.github/workflows/pr-archive-integrity.yml
+++ b/.github/workflows/pr-archive-integrity.yml
@@ -1,7 +1,10 @@
-name: Pre-merge archive integrity
+name: Archive integrity
 
 on:
   pull_request:
+    branches:
+      - main
+  push:
     branches:
       - main
   workflow_dispatch:
@@ -24,7 +27,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Check out the pull request
-        uses: actions/checkout@v7
+        uses: actions/checkout@v6
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -40,9 +43,7 @@ jobs:
         run: python tools/validate_manifests.py
 
       - name: Verify generated modlists are current
-        run: |
-          python tools/generate_modlist_markdown.py
-          git diff --exit-code -- editions/openmw/MODLIST.md editions/mwse/MODLIST.md
+        run: python tools/generate_modlist_markdown.py --check
 
       - name: Review edition drift
         run: python tools/compare_editions.py

--- a/.github/workflows/pr-repository-checks.yml
+++ b/.github/workflows/pr-repository-checks.yml
@@ -1,7 +1,10 @@
-name: Pre-merge repository checks
+name: Repository checks
 
 on:
   pull_request:
+    branches:
+      - main
+  push:
     branches:
       - main
   workflow_dispatch:
@@ -24,7 +27,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Check out the pull request
-        uses: actions/checkout@v7
+        uses: actions/checkout@v6
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -45,7 +48,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Check out the pull request
-        uses: actions/checkout@v7
+        uses: actions/checkout@v6
 
       - name: Set up Python
         uses: actions/setup-python@v6

--- a/AGENT-RULES.md
+++ b/AGENT-RULES.md
@@ -44,10 +44,12 @@ From `ash-archive/`:
 ```bash
 python tools/lint_repo.py
 python tools/validate_manifests.py
-python tools/generate_modlist_markdown.py
-python tools/compare_editions.py
 python tools/check_duplicate_mods.py
+python tools/compare_editions.py
+python tools/generate_modlist_markdown.py --check
 pytest
 ```
 
-If a command is not run, state why in the PR.
+Run `python tools/generate_modlist_markdown.py` after manifest changes that affect public
+output, review the diff, and then run the `--check` command above. If a command is not run,
+state why in the PR.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,136 +1,136 @@
-# Contributing to TheDreamIsTheDoor / Ash Archive
+# Contributing to Ash Archive
 
-Thank you for contributing.
+Ash Archive is a planning/control repository for two sibling Morrowind editions:
 
-This repository is a planning/control repo for **Ash Archive**, organized under `ash-archive/`, with two sibling editions:
+- **Pilgrim Edition** targets OpenMW.
+- **Sleeper Edition** targets classic Morrowind + MCP + MGE XE + MWSE.
 
-- **Pilgrim Edition** (OpenMW)
-- **Sleeper Edition** (classic Morrowind + MCP + MGE XE + MWSE)
+Neither edition is currently installable or playable. Do not present planned entries,
+repository validation, upstream documentation, or a source link as in-game test evidence.
 
-The project is scaffold/planning-first. Do not present unverified compatibility claims as tested facts.
+## Before changing files
 
-## Repository layout
+Read [`AGENT-RULES.md`](AGENT-RULES.md), the
+[`PROJECT-BIBLE.md`](ash-archive/PROJECT-BIBLE.md), and the documentation for the affected
+edition or shared subsystem. Work on a focused branch, keep the pull request reviewable,
+and preserve intentional differences between the editions.
 
-- `ash-archive/editions/openmw/` — Pilgrim edition docs and manifests
-- `ash-archive/editions/mwse/` — Sleeper edition docs and manifests
-- `ash-archive/shared/` — shared categories, design rules, sourcing metadata
-- `ash-archive/tools/` — validation and markdown generation tooling
-- `ash-archive/tests/` — Python tests for tooling and schema checks
-- `ash-archive/PROJECT-BIBLE.md` — core project thesis and non-negotiable design constraints
+## Branch and commit conventions
 
-## Branch naming conventions
+Use a descriptive branch with an appropriate prefix such as `codex/`, `docs/`, `tooling/`,
+`manifests/`, `wabbajack/`, or `ci/`.
 
-Use focused branches with one of these prefixes:
+Use concise commit prefixes where helpful: `docs:`, `tools:`, `manifests:`, `shared:`,
+`openmw:`, `mwse:`, `tests:`, or `ci:`.
 
-- `codex/`
-- `copilot/`
-- `docs/`
-- `tooling/`
-- `manifests/`
-- `wabbajack/`
-- `ci/`
+## Install development dependencies
 
-Examples:
-- `docs/update-openmw-install-assumptions`
-- `tooling/manifest-error-improvements`
-- `manifests/mwse-status-transition-notes`
+From `ash-archive/`:
 
-## Commit message style
+```bash
+python -m pip install -e ".[dev]"
+```
 
-Use concise prefix-based commit messages:
+Python 3.11 or newer is required.
 
-- `docs:`
-- `tools:`
-- `manifests:`
-- `shared:`
-- `openmw:`
-- `mwse:`
-- `tests:`
-- `ci:`
+## Local validation
 
-Examples:
-- `docs: add governance guidance for PR scope`
-- `tools: improve duplicate detection messaging`
-- `shared: add sourced-mod verification fields`
-
-## Pull request expectations
-
-1. Keep PRs small and reviewable.
-2. Explain **what changed**, **why**, and **what did not change**.
-3. Include edition impact (Shared/OpenMW/MWSE/Tooling/Docs-only).
-4. Include validation results or a clear reason for any skipped checks.
-5. Do not mix unrelated changes in one PR.
-
-## Validation commands
-
-Run relevant checks from `ash-archive/`:
+The full CI-equivalent suite is:
 
 ```bash
 python tools/lint_repo.py
 python tools/validate_manifests.py
-python tools/generate_modlist_markdown.py
-python tools/compare_editions.py
 python tools/check_duplicate_mods.py
+python tools/compare_editions.py
+python tools/generate_modlist_markdown.py --check
 pytest
 ```
 
-Use a subset only when truly scope-limited; state what was run.
+Run commands from `ash-archive/`. A genuinely scope-limited change may justify a subset,
+but the pull request must list every skipped check and the reason. The optional
+`python tools/summarize_sourced_mods.py` command prints a candidate overview and is not a
+validation or release-readiness result.
 
-## Manifest change expectations
+Continuous integration runs the full suite on pull requests and pushes to `main`. These
+checks establish structural consistency, not gameplay compatibility, installability, or
+release readiness.
 
-Internal control metadata files use the `.meta` extension (commonly `.control.meta`) and remain YAML-structured for project tooling. These are separate from MO2 download sidecar `.meta` files and must not be represented as native sidecars.
+## Generated modlists
 
-When editing manifests:
+`editions/openmw/MODLIST.md` and `editions/mwse/MODLIST.md` contain manual introductions
+and generated sections delimited by `GENERATED-CONTENT` markers. Never hand-edit content
+between those markers.
+
+After a manifest change that affects public output:
+
+1. Run `python tools/generate_modlist_markdown.py`.
+2. Review both edition diffs, including unexpected removals or status changes.
+3. Run `python tools/generate_modlist_markdown.py --check` to confirm the committed view is current.
+
+## Metadata ownership
+
+Internal `.control.meta` files are YAML project metadata, not Mod Organizer 2 download
+sidecars. The main metadata layers have different responsibilities:
+
+| Layer | Canonical responsibility |
+|---|---|
+| `shared/sourced-mods.control.meta` | Candidate identity, source type, source URL, provenance evidence, source confidence, and candidate review state. |
+| `editions/*/manifests/mods.control.meta` | Edition choice, engine behavior, plugins, dependencies, conflicts, patches, testing evidence, and load-order relationships. |
+| `editions/*/MODLIST.md` | Generated public planning view; never the source of truth. |
+
+See the [`control metadata schema`](ash-archive/shared/mod-meta-schema.md) for field rules.
+
+## Source references and the two state systems
+
+An edition manifest entry may set `source_reference` to the ID of a canonical candidate in
+`shared/sourced-mods.control.meta`. A link may be added to an existing `planned` edition
+placeholder when identity and provenance match. The link does not fill unknown version or
+archive data and does not change either status automatically.
+
+Candidate intake uses `candidate_status` (`candidate`, `under-review`, `promoted`,
+`rejected`, or `superseded`). Edition manifests separately use `status` (`planned`,
+`testing`, `accepted`, `rejected`, `needs-patch`, or `deprecated`). Promotion and edition
+acceptance remain human-review decisions, and `testing`/`accepted` require recorded evidence.
+Follow the [`Sourced Mod Workflow`](ash-archive/shared/sourced-mod-workflow.md).
+
+## Manifest changes
+
+When editing an edition manifest:
 
 1. Keep OpenMW and MWSE as sibling implementations, not forced parity.
-2. Preserve category integrity against `shared/categories.control.meta`.
-3. Preserve cross-edition status intent and explicit rationale.
-4. Avoid speculative metadata.
-5. Do not mark compatibility as tested without documented evidence.
+2. Use a category from `shared/categories.control.meta`.
+3. Keep IDs lowercase kebab-case and priorities unique within a category.
+4. Use only engine values supported by that edition.
+5. Reference existing IDs in requirements, conflicts, and load-order fields.
+6. Leave unknown source, version, archive, plugin, and compatibility facts explicitly unknown.
+7. Do not set `testing` or `accepted` without the evidence required by validation and human review.
+8. Preserve rejection reasoning.
 
-## Mod sourcing expectations
+## Source research
 
-When updating sourcing records:
+When updating a canonical source record:
 
-1. Record evidence and confidence explicitly.
-2. Distinguish candidate vs accepted status clearly.
-3. Do not invent URLs, archive names, or version identifiers.
-4. Do not mark mods accepted without review/testing notes.
+1. Prefer current primary sources and record what the evidence actually establishes.
+2. Distinguish source confidence from compatibility evidence.
+3. Do not invent URLs, IDs, versions, archive names, plugin names, or redistribution terms.
+4. Keep unresolved identity, licensing, or package questions blocked or unverified.
+5. Do not promote or accept a candidate merely because its source URL is verified.
 
+## Documentation changes
 
-## Sourced-mod candidate workflow
+Keep status language tied to repository evidence. Placeholder pages must say what is blocked
+and what evidence is needed; an empty known-issues page must not imply that no issues exist.
+Preserve the dual-edition model and the design constraints in the project bible.
 
-Use `ash-archive/shared/sourced-mod-workflow.md` when triaging or promoting sourced candidates.
-Treat `shared/sourced-mods.control.meta` as candidate intake metadata, not an accepted-mod manifest.
+## Design-bible exceptions
 
-## Documentation expectations
+If a proposal conflicts with the project bible, add a clearly labeled **Design-Bible
+Exception Request** to the pull request. Identify the exact rule, rationale, alternatives,
+and risk. A maintainer must review the exception; do not silently weaken the rule in prose or
+metadata.
 
-1. Keep docs aligned with current repo state (planning/scaffold where applicable).
-2. Avoid language that implies release-ready installer state unless true.
-3. Preserve project horror direction: Morrowind-native, evidence-first, no crossover IP content.
+## Pull request expectations
 
-## Documenting uncertainty
-
-When facts are incomplete:
-
-- Use explicit uncertainty wording (for example: "unverified", "needs confirmation", "TBD").
-- Add what evidence is missing and what test/check would confirm it.
-- Never replace unknowns with invented details.
-
-## Handling OpenMW vs MWSE differences
-
-1. Prefer edition-appropriate solutions over artificial parity.
-2. Explain when behavior intentionally differs between editions.
-3. Do not collapse both editions into a shared load order.
-
-## Proposing design-bible exceptions
-
-If a change appears to conflict with `ash-archive/PROJECT-BIBLE.md`:
-
-1. Open a PR with a clearly labeled **Design-Bible Exception Request** section.
-2. Explain the exact rule affected, rationale, alternatives considered, and risk.
-3. Do not merge exception-like changes without human maintainer review.
-
-## Additional agent guidance
-
-AI agents should also follow `AGENT-RULES.md`.
+Describe what changed, why it changed, affected editions, validation results, skipped checks,
+and remaining uncertainty. Explicitly separate repository/tooling results from source facts
+and from in-game evidence. Do not mix unrelated work.

--- a/README.md
+++ b/README.md
@@ -1,132 +1,130 @@
 # Ash Archive
 
-**Ash Archive** is a dual-edition Morrowind Wabbajack modlist built around psychological horror native to Vvardenfell. The project is contained in the [`ash-archive`](ash-archive/) sub-directory and ships as two sibling editions that share aesthetic pillars and narrative logic while using engine-specific techniques.
-
----
+**Ash Archive** is a planning and control repository for a dual-edition Morrowind
+Wabbajack project built around psychological horror native to Vvardenfell. The project
+lives under [`ash-archive/`](ash-archive/) and is designed as two sibling editions that
+share aesthetic pillars while using engine-specific implementations.
 
 ## Editions
 
-| Edition | Engine | Tagline |
+| Edition | Engine target | Design emphasis |
 |---|---|---|
-| **Ash Archive: Pilgrim Edition** | OpenMW | *The island remembers.* |
-| **Ash Archive: Sleeper Edition** | Classic Morrowind + MCP + MGE XE + MWSE | *The dream notices you.* |
+| **Ash Archive: Pilgrim Edition** | OpenMW | Long-play stability, distance, documents, tomb architecture, and environmental pressure. |
+| **Ash Archive: Sleeper Edition** | Classic Morrowind + MCP + MGE XE + MWSE | Reactive dream contamination, identity fracture, and configurable scripted dread. |
 
-**Pilgrim Edition** is stable, atmospheric, and long-play-focused. It emphasises weather, distance, documents, tomb architecture, and retrospective dread through environmental pressure.
-
-**Sleeper Edition** is script-heavy and reactive. It uses MWSE to deliver dream contamination, identity fracture, and sleep-state horror through event timing and ritual repetition.
-
----
-
-## Design pillars
-
-- **The Island Remembers** — Vvardenfell is already haunted by prophecy, reincarnation, and suppressed history.
-- **The Dream is Geological** — dread accumulates in strata, not moments.
-- **Reincarnation is Body Horror** — the Nerevarine arc treated as violation, not triumph.
-- **Dagoth Ur is Intimate, Not Loud** — the antagonist as contamination, not spectacle.
-- **The Tribunal Are the Beautiful Crime Scene** — divinity as cover-up.
-- **Evidence Before Explanation** — logs, notes, shrines, and rumours foreshadow; nothing is explained twice.
-
-Horror emerges from Morrowind's own systems and lore. No horror-franchise crossover content, no generic jump scares, no Skyrimification.
-
----
+The editions are not interchangeable load orders. Shared candidate provenance does not
+imply identical inclusion, behavior, patches, or acceptance in both editions.
 
 ## Current status
 
-> **Planning and scaffold only.** The list is not yet installable, not yet playable, and does not define a final load order.
+> **Planning and scaffold only.** Neither edition is installable or playable, no final
+> load order exists, and the repository contains no completed end-to-end install test.
 
-See [ROADMAP.md](ash-archive/ROADMAP.md) for the phased plan and [CHANGELOG.md](ash-archive/CHANGELOG.md) for version history.
+The descriptions above are design targets, not compatibility or stability claims. See the
+[`ROADMAP.md`](ash-archive/ROADMAP.md) for phase gates and
+[`FOLLOW-UP-TASKS.md`](ash-archive/FOLLOW-UP-TASKS.md) for unresolved work.
 
----
+## Design direction
 
-## Prerequisites
+The project treats Vvardenfell as haunted by prophecy, reincarnation, and suppressed
+history. Its core rule is **evidence before explanation**: documents, spaces, rumors, and
+repetition should foreshadow dread before explicit revelation. Horror must emerge from
+Morrowind's own systems and lore; direct franchise crossovers, generic jump scares,
+Skyrimification, and convenience changes that erase pilgrimage friction are out of scope.
 
-- **Python 3.11+**
-- **PyYAML** (runtime dependency)
-- **pytest**, **ruff**, and **yamllint** (development/testing)
-
----
-
-## Setup
-
-From inside `ash-archive/`:
-
-```bash
-# Install runtime and development dependencies
-pip install -e ".[dev]"
-```
-
----
+The complete, non-negotiable constraints live in the
+[`PROJECT-BIBLE.md`](ash-archive/PROJECT-BIBLE.md).
 
 ## Repository structure
 
-```
+```text
 AshArchive/
-├── .agents/skills/            # Repo-scoped reusable Codex workflows
-├── .codex/agents/             # Repo-scoped Codex agent configurations
-├── ash-archive/              # Main project root
-│   ├── editions/
-│   │   ├── openmw/           # Pilgrim Edition manifests and docs
-│   │   └── mwse/             # Sleeper Edition manifests and docs
-│   ├── shared/               # Categories, design rules, evaluation rubric
-│   ├── tools/                # Python validation and generation scripts
-│   ├── tests/                # Python tests for tooling and schema checks
-│   ├── PROJECT-BIBLE.md      # Full design philosophy and horror translation notes
-│   ├── ROADMAP.md
-│   └── CHANGELOG.md
+├── .agents/presets/           # Canonical runner-neutral local-agent presets
+├── .agents/skills/            # Repo-scoped reusable workflows
+├── .codex/agents/             # Runnable Codex translations of the presets
+├── .github/workflows/         # Continuous integration
+├── ash-archive/               # Python project and Ash Archive control data
+│   ├── editions/openmw/       # Pilgrim manifests, generated modlist, and docs
+│   ├── editions/mwse/         # Sleeper manifests, generated modlist, and docs
+│   ├── shared/                # Canonical sourcing data and shared policies
+│   ├── tools/                 # Validation, comparison, and generation scripts
+│   └── tests/                 # Tooling and policy regression tests
+├── modlist.txt                # Imported source inventory snapshot
 ├── CONTRIBUTING.md
 └── README.md
 ```
 
-Internal control metadata lives in YAML `.control.meta` files used by project tooling and is **not** the same as MO2 download sidecar `.meta` files. See `ash-archive/shared/mo2-download-meta-sidecars.md` for the distinction.
+YAML `.control.meta` files are internal project metadata. They are not native Mod
+Organizer 2 download sidecar `.meta` files and must not be synthesized as such. See
+[`MO2 Download Sidecars vs Internal Metadata`](ash-archive/shared/mo2-download-meta-sidecars.md).
 
----
+## Metadata flow
 
-## Tooling quick start
+[`shared/sourced-mods.control.meta`](ash-archive/shared/sourced-mods.control.meta) is the
+canonical provenance layer for candidate source type, source URL, and source evidence. An
+edition entry may use `source_reference` to point to one of those candidate IDs.
 
-All commands are run from inside `ash-archive/`.
+That link is provenance-only. It does **not** promote the candidate, accept the mod, prove
+compatibility, or copy unknown versions and archive names into an edition manifest. Edition
+manifests continue to own engine behavior, plugins, requirements, conflicts, patches,
+testing notes, and load-order relationships. The full lifecycle and its two independent
+status systems are documented in the
+[`Sourced Mod Workflow`](ash-archive/shared/sourced-mod-workflow.md).
+
+## Setup and local checks
+
+Python 3.11 or newer is required. From `ash-archive/`:
 
 ```bash
-# Lint Python, YAML, agent TOML, and repo skills
+python -m pip install -e ".[dev]"
+
 python tools/lint_repo.py
-
-# Validate manifests
 python tools/validate_manifests.py
-
-# Generate modlist markdown
-python tools/generate_modlist_markdown.py
-
-# Compare editions
-python tools/compare_editions.py
-
-# Check for duplicate mods across editions
 python tools/check_duplicate_mods.py
-
-# Summarise sourced-mod candidates
-python tools/summarize_sourced_mods.py
-
-# Run the test suite
+python tools/compare_editions.py
+python tools/generate_modlist_markdown.py --check
 pytest
 ```
 
----
+`python tools/summarize_sourced_mods.py` is an optional read-only candidate report; it is
+not a release or compatibility check.
+
+To intentionally refresh generated modlists after a manifest change, run
+`python tools/generate_modlist_markdown.py`, review both diffs, and then rerun with
+`--check`. Only the content between `GENERATED-CONTENT` markers in
+`editions/*/MODLIST.md` is generated; do not edit those sections by hand.
+
+## Continuous integration
+
+The [`Repository checks`](.github/workflows/pr-repository-checks.yml) and
+[`Archive integrity`](.github/workflows/pr-archive-integrity.yml) workflows run on pull
+requests and pushes to `main`. They use Python 3.11 to run repository lint, manifest and
+source-reference validation, duplicate scanning, edition comparison, the read-only
+generated-file check, and the test suite. Passing CI validates repository structure and
+consistency only; it is not evidence of an installable list or in-game compatibility.
 
 ## Documentation
 
-- [Project Bible](ash-archive/PROJECT-BIBLE.md) — thesis, dual-edition philosophy, horror translation notes, and core atmosphere rules
-- [Roadmap](ash-archive/ROADMAP.md) — development phases from scaffold to Wabbajack release
-- [Pilgrim Edition](ash-archive/editions/openmw/README.md) — OpenMW edition identity and scope
-- [Sleeper Edition](ash-archive/editions/mwse/README.md) — MWSE edition identity and scope
-- [Changelog](ash-archive/CHANGELOG.md)
-- [Local Agent Presets](ash-archive/LOCAL-AGENT-PRESETS.md) — repo-scoped agents and skills for safe maintenance tasks
+- [`ash-archive/README.md`](ash-archive/README.md) — control-data model, automation boundaries, and contributor navigation
+- [`Project Bible`](ash-archive/PROJECT-BIBLE.md) — project thesis and design constraints
+- [`Roadmap`](ash-archive/ROADMAP.md) — development phases and release gates
+- [`Sourced Mod Workflow`](ash-archive/shared/sourced-mod-workflow.md) — candidate intake, source links, evaluation, and promotion
+- [`Control Metadata Schema`](ash-archive/shared/mod-meta-schema.md) — field ownership and validation rules
+- [`Pilgrim Edition`](ash-archive/editions/openmw/README.md) — OpenMW scope and documentation
+- [`Sleeper Edition`](ash-archive/editions/mwse/README.md) — MWSE scope and documentation
+- [`Local Agent Presets`](ash-archive/LOCAL-AGENT-PRESETS.md) — conservative maintenance agents and review gates
 
----
+See [`CONTRIBUTING.md`](CONTRIBUTING.md) before changing manifests, tools, or planning
+documents.
 
-## Contributing
+## Security
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for branch naming conventions, commit style, PR expectations, validation commands, and guidelines for manifest and mod-sourcing changes.
+The project has no released installer or supported runtime version. Repository-tooling
+security guidance is in [`SECURITY.md`](SECURITY.md).
 
----
+## License status
 
-## License
-
-See [LICENSE.md](ash-archive/LICENSE.md).
+Licensing requires maintainer review. The repository-root [`LICENSE`](LICENSE) contains
+CC0 1.0 text, while [`ash-archive/LICENSE.md`](ash-archive/LICENSE.md) contains incomplete,
+conflicting MIT text. This documentation does not choose between them; do not treat the
+nested file as an authoritative grant until the conflict is resolved.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,21 +1,24 @@
 # Security Policy
 
-## Supported Versions
+## Supported versions
 
-Use this section to tell people about which versions of your project are
-currently being supported with security updates.
+Ash Archive has no released Wabbajack installer and no supported playable version. The
+repository is a planning/control scaffold. Security fixes for the Python tooling, continuous
+integration, and repository configuration are made on the current `main` branch; this is not
+a promise of modlist runtime support.
 
-| Version | Supported          |
-| ------- | ------------------ |
-| 5.1.x   | :white_check_mark: |
-| 5.0.x   | :x:                |
-| 4.0.x   | :white_check_mark: |
-| < 4.0   | :x:                |
+## Reporting a vulnerability
 
-## Reporting a Vulnerability
+Do not publish secrets, personal data, or working exploit details in a public issue.
 
-Use this section to tell people how to report a vulnerability.
+If GitHub displays a **Report a vulnerability** option on this repository's Security page,
+use that private channel. If it is not available, contact the maintainer through their GitHub
+profile to request a private channel before sharing sensitive details. The repository does
+not currently document a response-time commitment, so this policy does not invent one.
 
-Tell them where to go, how often they can expect to get an update on a
-reported vulnerability, what to expect if the vulnerability is accepted or
-declined, etc.
+Non-sensitive defects in validation, generation, CI, or repository configuration may be
+reported through the repository's public issue tracker.
+
+Mod compatibility problems, load-order conflicts, and incomplete planning records are not
+security vulnerabilities unless they also create a concrete security impact in repository
+tooling or distributed artifacts.

--- a/ash-archive/.gitignore
+++ b/ash-archive/.gitignore
@@ -3,3 +3,6 @@ __pycache__/
 .pytest_cache/
 .venv/
 *.log
+*.egg-info/
+build/
+dist/

--- a/ash-archive/CHANGELOG.md
+++ b/ash-archive/CHANGELOG.md
@@ -1,4 +1,12 @@
 # Changelog
 
+## [Unreleased]
+- Add Python 3.11 continuous integration for repository lint, validation, comparison,
+  deterministic generated-file checks, and tests.
+- Add provenance-only links between canonical sourced candidates and edition planning entries.
+- Strengthen validation and document the separation between automated consistency checks and
+  human compatibility, acceptance, and release decisions.
+- Replace misleading documentation placeholders with explicit blocked-state guidance.
+
 ## [0.1.0] - 2026-04-25
 - Initial scaffold and tooling for Ash Archive control repository.

--- a/ash-archive/FOLLOW-UP-TASKS.md
+++ b/ash-archive/FOLLOW-UP-TASKS.md
@@ -1,54 +1,83 @@
 # Follow-up Tasks
 
-This task list tracks the immediate work needed to finish **Phase 1 - Sourcing** and prepare the project for **Phase 2 - Evaluation**.
+This list tracks remaining work for **Phase 1 - Sourcing** and preparation for
+**Phase 2 - Evaluation**. Repository hardening does not clear source, compatibility, or
+in-game testing blockers.
 
-## Milestone target: Phase 1 sourcing exit
+## Source triage gate
 
-Phase 1 is complete when candidate pools are sufficiently populated across major categories for both editions, validation passes cleanly, and all active candidates have provenance plus decision notes.
+- [ ] Resolve every blocking question in `shared/source-triage.control.meta`.
+- [ ] Decide whether official plugins and DLC are baseline requirements, manual-only
+  prerequisites, or source-tracked candidates.
+- [ ] Identify canonical sources, package identities, and distribution constraints for
+  `source unknown`, Nexus ID `0`, and unmanaged entries.
+- [ ] Keep blocked entries unverified until identity, source, and licensing questions are resolved.
+- [ ] Close `source_triage.triage_status` only after every promotion-gate blocker is resolved.
 
-### Source triage gate
+## Candidate intake expansion
 
-- [ ] Resolve every open blocking question in `shared/source-triage.control.meta`.
-- [ ] Decide whether official plugins and DLC entries are baseline requirements, manual-only prerequisites, or source-tracked candidates.
-- [ ] Identify canonical sources, package identities, and distribution constraints for `source unknown` and Nexus ID `0` entries.
-- [ ] Keep blocked entries `unverified` until package identity, source, and licensing questions are resolved.
-- [ ] Close `source_triage.triage_status` only after all promotion-gate blockers are resolved.
+- [ ] Expand `shared/sourced-mods.control.meta` beyond the current dream, blight, and survival groups.
+- [ ] Add candidates for foundation, preservation, architecture, soundscape, UI/journal,
+  faith/Temple, and other underrepresented categories.
+- [ ] Record stable IDs, primary source URLs, evidence notes, source confidence,
+  compatibility status, thematic bucket, promotion target, risk, and engine uncertainty.
+- [ ] Keep compatibility `unverified` or `needs-testing` unless reliable documentation or
+  recorded test evidence supports a stronger value.
+- [ ] Retain rejected and superseded candidates with explicit reasoning.
 
-### Candidate intake expansion
+## Source-to-manifest links
 
-- [ ] Expand `shared/sourced-mods.control.meta` beyond the current dream, blight, and survival buckets.
-- [ ] Add candidates for underrepresented major categories in both editions, especially foundation, preservation, architecture, soundscape, UI/journal, and faith/Temple themes.
-- [ ] Record stable kebab-case IDs, source URLs, evidence notes, source confidence, compatibility status, thematic bucket, promotion target, risk level, and engine notes for each new candidate.
-- [ ] Leave compatibility as `unverified` or `needs-testing` unless there is documented test evidence or reliable upstream documentation.
-- [ ] Retain rejected candidates with explicit rejection reasoning instead of deleting them.
+- [ ] Add `source_reference` only where an edition entry and canonical candidate represent
+  the same mod identity and intended edition.
+- [ ] Keep `related_manifest_ids` synchronized with manifest links.
+- [ ] Do not interpret a source link as candidate promotion, edition acceptance, or testing.
+- [ ] Leave edition-specific version, archive, plugin, patch, conflict, and load-order facts
+  blank or explicitly unknown until evidence exists.
+- [ ] Resolve any remaining manifest candidates that have trustworthy repository-recorded
+  provenance but no canonical source record.
 
-### Multi-package source metadata
+## Multi-package source metadata
 
-- [ ] Audit `shared/source-package-meta.control.meta` for multi-package sources that need child package records.
-- [ ] Confirm each package has an install artifact, variant name, edition notes, and plugin list.
-- [ ] Add child `package_version` values when a package differs from the parent `base_version`.
-- [ ] Keep parent source metadata stable when only one child package version diverges.
+- [ ] Audit `shared/source-package-meta.control.meta` for source pages with multiple installable packages.
+- [ ] Confirm each package's identity, variant, artifact evidence, edition notes, and plugin list.
+- [ ] Use child `package_version` only when it differs from the verified parent `base_version`.
+- [ ] Distinguish imported local-path evidence from a portable, verified archive identity.
 
-### Phase 2 evaluation preparation
+## Phase 2 evaluation preparation
 
-- [ ] Define the first evaluation batches by category and test route.
-- [ ] Start with high-impact horror candidates: Sixth House/dream, blight/ambience, and MWSE survival/body-pressure candidates.
-- [ ] Prepare evaluation notes for compatibility, conflicts, mitigation paths, and edition-specific behavior.
-- [ ] Do not promote candidates into edition manifests until human review confirms the evaluation evidence.
+- [ ] Define the first evaluation batches by category and route.
+- [ ] Start with high-impact Sixth House/dream, blight/ambience, and MWSE body-pressure candidates.
+- [ ] Expand `shared/mod-evaluation-rubric.md` with maintainer-approved weighting or decision thresholds if needed.
+- [ ] Record compatibility, conflicts, mitigations, performance, and edition-specific behavior.
+- [ ] Keep candidate promotion and edition status advancement as separate human-review decisions.
 - [ ] Preserve intentional OpenMW/MWSE differences rather than forcing feature parity.
 
-### Placeholder manifest cleanup
+## Edition evidence and documentation
 
-- [ ] Replace `source: "tbd"` and empty source/version/archive fields only when verified provenance exists.
-- [ ] Update patch notes, testing notes, requirements, conflicts, and load-order notes as evaluation evidence becomes available.
-- [ ] Keep placeholder entries marked `planned` until they have enough evidence to advance.
-- [ ] Regenerate modlist markdown after manifest updates.
+- [ ] Build the first reproducible Pilgrim installation before replacing its blocked installation/post-install pages.
+- [ ] Build the first reproducible Sleeper installation before replacing its blocked installation/post-install pages.
+- [ ] Define and execute edition-specific load-order, performance, and test-route evidence.
+- [ ] Populate known issues from observed builds; an empty issue list is not evidence of zero issues.
+- [ ] Record compiler inputs and clean-install results before checking any release-readiness item.
 
-### Validation checklist
+## Maintainer decisions
 
-- [ ] Run `python tools/validate_manifests.py` after each metadata batch.
-- [ ] Run `python tools/generate_modlist_markdown.py` after manifest changes.
-- [ ] Run `python tools/compare_editions.py` after cross-edition status changes.
-- [ ] Run `python tools/check_duplicate_mods.py` after adding or renaming candidates.
-- [ ] Run `pytest` before opening milestone-completion PRs.
+- [ ] Resolve the conflict between the root CC0 `LICENSE` and the incomplete nested MIT `LICENSE.md`.
+- [ ] Confirm a private security-reporting channel and update `SECURITY.md` with it.
+- [ ] Approve any candidate promotion, compatibility conclusion, edition acceptance, final
+  load order, design-bible exception, or release-readiness decision.
 
+## Validation checklist
+
+Run from `ash-archive/` after each applicable batch:
+
+- [ ] `python tools/lint_repo.py`
+- [ ] `python tools/validate_manifests.py`
+- [ ] `python tools/check_duplicate_mods.py` after adding or renaming manifest entries
+- [ ] `python tools/compare_editions.py` after cross-edition changes
+- [ ] `python tools/generate_modlist_markdown.py` after manifest changes, followed by diff review
+- [ ] `python tools/generate_modlist_markdown.py --check`
+- [ ] `pytest` before opening or updating a pull request
+
+Use `python tools/summarize_sourced_mods.py` as a read-only intake report when reviewing
+candidate coverage; it is not a compatibility check.

--- a/ash-archive/LOCAL-AGENT-PRESETS.md
+++ b/ash-archive/LOCAL-AGENT-PRESETS.md
@@ -1,6 +1,10 @@
 # Local Agent Presets
 
-This document defines reusable local agent presets for routine Ash Archive maintenance. The presets are intentionally conservative: agents may prepare evidence, apply mechanical updates, and run validation, but they must not invent provenance, compatibility evidence, or release readiness.
+This document explains the reusable local agent presets for routine Ash Archive maintenance.
+The machine-auditable YAML files in `../.agents/presets/` are canonical; the Codex TOML
+agents and repo-scoped skills bind to those presets. All layers are intentionally conservative:
+agents may prepare evidence, apply authorized mechanical updates, and run validation, but
+they must not invent provenance, compatibility evidence, or release readiness.
 
 ## Shared operating rules
 
@@ -20,10 +24,10 @@ Every preset must follow these baseline constraints before doing specialized wor
 |---|---|---|---|---|
 | `source-triage-agent` | Turn open sourcing questions into evidence-backed triage notes. | `shared/source-triage.control.meta`, `shared/sourced-mods.control.meta`, `shared/source-package-meta.control.meta` | Draft and annotate only; do not promote candidates. | `python tools/validate_manifests.py`, `pytest tests/test_sourced_mods.py` |
 | `manifest-lint-agent` | Repair schema, naming, ordering, and convention issues reported by tooling. | `shared/*.control.meta`, `editions/*/manifests/*.control.meta` | May apply mechanical fixes that are directly implied by validation output. | `python tools/validate_manifests.py`, `pytest tests/test_validation.py tests/test_control_meta_conventions.py` |
-| `modlist-regenerator` | Regenerate derived modlist markdown after manifest edits. | `editions/*/MODLIST.md`, manifest files when needed for context | Generated output only; do not hand-edit generated sections. | `python tools/generate_modlist_markdown.py`, `python tools/validate_manifests.py` |
+| `modlist-regenerator` | Regenerate derived modlist markdown after manifest edits. | `editions/*/MODLIST.md`, manifest files when needed for context | Generated output only; do not hand-edit generated sections. | `python tools/generate_modlist_markdown.py`, diff review, `python tools/generate_modlist_markdown.py --check`, `python tools/validate_manifests.py` |
 | `edition-drift-auditor` | Identify unintended divergence between OpenMW and MWSE editions. | `editions/openmw/**`, `editions/mwse/**`, `tools/compare_editions.py` | Report or annotate; do not force parity when divergence is intentional. | `python tools/compare_editions.py`, `python tools/check_duplicate_mods.py` |
 | `documentation-sync-agent` | Keep README, roadmap, checklist, and policy references synchronized. | `README.md`, `ROADMAP.md`, `FOLLOW-UP-TASKS.md`, `editions/*/docs/*.md` | May edit prose and links; must not change project scope without explicit request. | `pytest` when tooling docs change; otherwise markdown review only. |
-| `release-readiness-agent` | Prepare Wabbajack release checklist status summaries. | `editions/*/wabbajack/*.md`, `editions/*/docs/*.md`, manifests | Checklist and gap reporting only until human release review. | `python tools/validate_manifests.py`, `python tools/generate_modlist_markdown.py`, `pytest` |
+| `release-readiness-agent` | Prepare Wabbajack release checklist status summaries. | `editions/*/wabbajack/*.md`, `editions/*/docs/*.md`, manifests | Checklist and gap reporting only until human release review. | `python tools/validate_manifests.py`, `python tools/generate_modlist_markdown.py --check`, `pytest` |
 | `wabbajack-list-planner` | Prepare evidence-backed direction for the Pilgrim and Sleeper lists. | `PROJECT-BIBLE.md`, shared and edition manifests, edition Wabbajack docs | Advisory planning only; do not accept, promote, place, or order mods. | `python tools/validate_manifests.py`, `python tools/compare_editions.py`, `python tools/check_duplicate_mods.py` when relevant |
 | `wabbajack-list-writer` | Draft restrained, edition-specific Wabbajack prose. | Root and edition README files, changelogs, Wabbajack and installation docs | Draft copy only; material claims and final public wording require evidence and human review. | `python tools/validate_manifests.py` for inventory claims, `pytest` for tooling-backed docs or tests |
 
@@ -276,13 +280,13 @@ metadata. `tests/test_repo_skills.py` also keeps the checked-in skill set under 
 
 ## Automation rollout plan
 
-1. **Document-first pass** - keep this plan as the canonical description of safe agent behavior. **Complete.**
+1. **Document-first pass** - keep this document as the human-readable policy and preset index. **Complete.**
 2. **Repo-agent configuration** - maintain runner-neutral YAML presets and project-scoped Codex TOML translations with automated consistency checks. **Complete.**
 3. **Repo-skill configuration** - maintain discoverable repo workflows and lint them against their canonical presets. **Complete.**
-4. **Dry-run prompts** - test each preset against a copied branch and require read-only summaries before allowing edits.
-5. **Mechanical-edit enablement** - allow `manifest-lint-agent` and `modlist-regenerator` to write changes after their checks are stable.
-6. **Evidence workflows** - allow `source-triage-agent` to annotate records only when citations and uncertainty logs are included.
-7. **Release workflows** - keep `release-readiness-agent` advisory-only until Phase 4 release preparation.
+4. **Guardrail enforcement** - keep exact preset-to-agent and preset-to-skill bindings, forbidden actions, stop conditions, and human gates under test. **Complete.**
+5. **Mechanical maintenance** - permit only the file-scoped edits authorized by each canonical preset; generated output and validator-implied repairs remain reviewable. **Enabled with validation.**
+6. **Evidence workflows** - permit source annotations only when evidence and uncertainty are retained; promotion and compatibility decisions remain human-gated. **Enabled with human gates.**
+7. **Release workflows** - keep `release-readiness-agent` advisory-only until a human authorizes release work. **Advisory only.**
 
 ## Human review gates
 

--- a/ash-archive/README.md
+++ b/ash-archive/README.md
@@ -1,26 +1,77 @@
-# Ash Archive
+# Ash Archive Control Project
 
-Ash Archive is a control repository for a dual-edition Morrowind Wabbajack project built around Morrowind-native psychological horror design.
+This directory contains the Python tooling, control metadata, generated planning views, and
+edition documentation for Ash Archive. The repository plans two sibling Wabbajack editions:
 
-## Editions
-- **Ash Archive: Pilgrim Edition** (OpenMW) — *The island remembers.*
-- **Ash Archive: Sleeper Edition** (classic Morrowind + MCP + MGE XE + MWSE) — *The dream notices you.*
+- **Pilgrim Edition** targets OpenMW.
+- **Sleeper Edition** targets classic Morrowind + MCP + MGE XE + MWSE.
 
-## Current status
-This repository is **planning and scaffold only**. It is not yet a final Wabbajack installer, not yet playable, and does not define a final load order.
+## Current state
 
-## Tooling quick start
-From `ash-archive/`:
+Neither edition is installable or playable, no final load order exists, and no end-to-end
+install result is recorded. Repository validation proves structural consistency only; it
+does not prove mod compatibility or release readiness.
 
-- Lint Python and repository configuration:
-  - `python tools/lint_repo.py`
-- Validate manifests:
-  - `python tools/validate_manifests.py`
-- Generate modlist markdown:
-  - `python tools/generate_modlist_markdown.py`
-- Compare editions:
-  - `python tools/compare_editions.py`
-- Check for duplicate mods:
-  - `python tools/check_duplicate_mods.py`
-- Run tests:
-  - `pytest`
+## Control-data model
+
+The repository separates shared provenance from edition decisions:
+
+1. `shared/sourced-mods.control.meta` records candidate identity, source facts, evidence,
+   uncertainty, and candidate-review state.
+2. An edition manifest entry may point to a canonical candidate with `source_reference`.
+3. Edition manifests retain engine, plugin, dependency, conflict, patch, testing, and
+   load-order fields.
+4. `editions/*/MODLIST.md` renders a planning view from edition manifests.
+
+A source reference is not promotion, acceptance, compatibility evidence, or an instruction
+to copy unknown version/archive data. See
+[`shared/sourced-mod-workflow.md`](shared/sourced-mod-workflow.md) and
+[`shared/mod-meta-schema.md`](shared/mod-meta-schema.md).
+
+## Automated checks
+
+From this directory, install Python 3.11 development dependencies and run the CI-equivalent
+suite:
+
+```bash
+python -m pip install -e ".[dev]"
+
+python tools/lint_repo.py
+python tools/validate_manifests.py
+python tools/check_duplicate_mods.py
+python tools/compare_editions.py
+python tools/generate_modlist_markdown.py --check
+pytest
+```
+
+Continuous integration runs those checks on pull requests and pushes to `main`.
+`python tools/summarize_sourced_mods.py` is an optional read-only intake report.
+
+## Generated files
+
+Only the sections between `GENERATED-CONTENT` markers in the two edition `MODLIST.md` files
+are generated. After a manifest change, run:
+
+```bash
+python tools/generate_modlist_markdown.py
+python tools/generate_modlist_markdown.py --check
+```
+
+Review both diffs. Do not edit generated sections manually.
+
+## Manual and human-review work
+
+Automation cannot decide whether to accept or reject a mod, establish compatibility from
+playtesting, choose cross-edition parity, set a final load order, approve a design-bible
+exception, or declare a release ready. Unknown source, package, version, archive, licensing,
+and game-behavior facts remain blocked until evidence is recorded.
+
+## Navigation
+
+- [`PROJECT-BIBLE.md`](PROJECT-BIBLE.md) — design constraints
+- [`ROADMAP.md`](ROADMAP.md) — phase gates
+- [`FOLLOW-UP-TASKS.md`](FOLLOW-UP-TASKS.md) — active blockers and next work
+- [`shared/sourced-mod-workflow.md`](shared/sourced-mod-workflow.md) — candidate and promotion lifecycle
+- [`editions/openmw/README.md`](editions/openmw/README.md) — Pilgrim scope
+- [`editions/mwse/README.md`](editions/mwse/README.md) — Sleeper scope
+- [`../CONTRIBUTING.md`](../CONTRIBUTING.md) — contribution and validation rules

--- a/ash-archive/ROADMAP.md
+++ b/ash-archive/ROADMAP.md
@@ -1,65 +1,99 @@
 # Roadmap
 
-## Current state (April 2026)
-- Repository foundation is in place: dual-edition structure, schema-backed manifests, baseline docs, and validation/generation tooling.
-- Project remains **planning/scaffold**, not yet an installable or fully playable Wabbajack list.
+## Current state
 
-## Phase 0 - Scaffold (completed)
+- The dual-edition directory and manifest structure is established.
+- Pull requests and pushes to `main` are checked with Python 3.11 repository lint,
+  manifest/source-reference validation, duplicate scanning, edition comparison,
+  deterministic generated-modlist checking, and tests.
+- Shared sourced candidates can be linked to edition planning entries without duplicating
+  canonical provenance or implying promotion.
+- Most installer, load-order, performance, post-install, and in-game test documentation is
+  still blocked on real builds and recorded evidence.
+- The project remains a planning/control scaffold, not an installable or playable Wabbajack list.
+
+## Phase 0 - Repository foundation (completed)
+
 **Goal:** establish guardrails before content scaling.
 
 Completed outcomes:
-- Shared and per-edition manifest layout defined.
-- Validation and consistency tooling established.
-- Baseline documentation created for setup, policy, and testing flow.
+
+- Shared and per-edition control-data layouts exist.
+- Structural validation, deterministic generation checks, and CI are in place.
+- Agent and contribution guardrails preserve evidence standards and edition separation.
+- Documentation shells identify missing install, test, and release evidence without claiming it exists.
+
+Phase 0 completion means the planning repository is maintainable; it does not mean either
+edition has been assembled or tested.
 
 ## Phase 1 - Sourcing (active)
+
 **Goal:** build trustworthy candidate pools with traceable provenance.
 
 In-scope work:
-- Expand `shared/sourced-mods.control.meta` (.meta extension, YAML-structured content) with verified metadata and source links.
-- Keep triage and package metadata synchronized (`shared/source-triage.control.meta`, `shared/source-package-meta.control.meta`).
-- Track rejected options with retained reasoning.
+
+- Expand `shared/sourced-mods.control.meta` across underrepresented categories.
+- Resolve blockers in `shared/source-triage.control.meta` and maintain package relationships
+  in `shared/source-package-meta.control.meta`.
+- Link matching edition planning entries with optional `source_reference` values while
+  leaving unknown edition-specific fields unknown.
+- Retain rejected and superseded records with their reasoning.
 
 Exit criteria:
+
 - Candidate pools are sufficiently populated across major categories for both editions.
-- Validation passes with no structural issues.
+- Validation passes with no structural or source-reference issues.
 - Source provenance and decision notes are present for all active candidates.
+- Blocking identity, package, and distribution questions are either resolved or explicitly deferred.
 
 ## Phase 2 - Evaluation
-**Goal:** convert sourced candidates into evidence-based accept/reject decisions.
+
+**Goal:** turn sourced candidates into evidence-based, human-reviewed edition decisions.
 
 In-scope work:
-- Evaluate by category and test route using the shared rubric.
-- Record compatibility notes, conflicts, and mitigation paths.
-- Promote tested entries into edition manifests; document rejections with rationale.
+
+- Move candidate records through `candidate` and `under-review` using the shared rubric.
+- Test edition behavior by category and repeatable route.
+- Record conflicts, mitigation paths, and edition-specific behavior.
+- Promote candidates and advance edition status only when each action's separate evidence
+  and human-review requirements are met.
 
 Exit criteria:
+
 - Core categories have evaluated coverage for both editions.
-- Major conflicts are either resolved or explicitly deferred with notes.
-- Accepted entries include compatibility evidence.
+- Major conflicts are resolved or explicitly deferred with notes.
+- Promoted candidates and accepted edition entries have the required review and compatibility evidence.
 
 ## Phase 3 - Edition hardening
-**Goal:** stabilize each edition as a coherent, testable package.
+
+**Goal:** stabilize each edition as an independent, coherent, testable package.
 
 In-scope work:
-- Lock edition-level load-order policy enforcement.
-- Finalize patch strategy and external tool requirements.
-- Run repeated validation and checklist cycles for regression control.
+
+- Establish and test edition-specific load-order policy.
+- Finalize patch strategy, external tools, and reproducible setup requirements.
+- Run repeated install, performance, and test-route cycles and record regressions.
 
 Exit criteria:
+
 - Both editions have internally consistent manifests and patch plans.
-- Known issues are documented with severity and workarounds.
-- Release checklists are actionable and reproducible.
+- Known issues are documented with severity, evidence, and workarounds where available.
+- Installation, post-install, performance, and testing instructions are reproducible.
+- Release checklists describe verified evidence rather than placeholder intent.
 
 ## Phase 4 - Wabbajack release preparation
-**Goal:** ship installable builds with clear support boundaries.
+
+**Goal:** prepare installable builds with explicit support boundaries.
 
 In-scope work:
-- Freeze manifests for release candidates.
-- Produce final modlist exports and installer-facing documentation.
-- Perform end-to-end install tests and capture support notes.
+
+- Freeze human-approved release-candidate manifests.
+- Produce installer-facing documentation and release artifacts.
+- Perform clean end-to-end install tests for each edition.
+- Resolve or explicitly document licensing, distribution, and support boundaries.
 
 Exit criteria:
-- Install flow succeeds for each edition using documented steps.
-- Release notes and known issues are published.
-- Versioned release artifacts are ready for distribution.
+
+- The documented install flow succeeds independently for each edition.
+- Release notes, known issues, support boundaries, and checksums/artifacts are published.
+- A human reviewer approves release readiness for each edition.

--- a/ash-archive/editions/mwse/MODLIST.md
+++ b/ash-archive/editions/mwse/MODLIST.md
@@ -1,6 +1,9 @@
 # Modlist
 
-Manual intro text.
+This is a generated **planning view**, not an installable, tested, or accepted modlist.
+Edit the edition manifest and run `python tools/generate_modlist_markdown.py`; do not edit
+content between the generated markers. Status describes the edition record only, and a
+canonical source link does not itself prove compatibility or promotion.
 
 <!-- GENERATED-CONTENT:START -->
 ## Architecture of Memory
@@ -19,7 +22,7 @@ Manual intro text.
 - **Expansion Delay** (`expansion-delay`) — status: `planned`, engine: `mwse`, cross-edition: `equivalent-needed`. Reason: Initial candidate placeholder entry.
 
 ## Combat, Magic, and Embodiment
-- **Ashfall** (`ashfall`) — status: `planned`, engine: `mwse`, cross-edition: `mwse-only`. Reason: Initial candidate placeholder entry.
+- **Ashfall** (`ashfall`) — status: `planned`, engine: `mwse`, cross-edition: `mwse-only`. Reason: Planning placeholder linked to canonical sourcing metadata; not promoted or compatibility-tested.
 
 ## Dwemer Tonal Ruins
 - **Dwemer Mesh Improvement** (`dwemer-mesh-improvement`) — status: `planned`, engine: `mwse`, cross-edition: `equivalent-needed`. Reason: Initial candidate placeholder entry.
@@ -27,9 +30,9 @@ Manual intro text.
 
 ## Engine and Foundation
 - **Patch for Purists** (`patch-for-purists`) — status: `planned`, engine: `mwse`, cross-edition: `equivalent-needed`. Reason: Initial candidate placeholder entry.
-- **Morrowind Code Patch** (`morrowind-code-patch`) — status: `testing`, engine: `mcp`, cross-edition: `mwse-only`. Reason: Initial candidate placeholder entry.
-- **MGE XE** (`mge-xe`) — status: `testing`, engine: `mge-xe`, cross-edition: `mwse-only`. Reason: Initial candidate placeholder entry.
-- **MWSE** (`mwse`) — status: `testing`, engine: `mwse`, cross-edition: `mwse-only`. Reason: Initial candidate placeholder entry.
+- **Morrowind Code Patch** (`morrowind-code-patch`) — status: `planned`, engine: `mcp`, cross-edition: `mwse-only`. Reason: Engine prerequisite placeholder; no repository test evidence is recorded.
+- **MGE XE** (`mge-xe`) — status: `planned`, engine: `mge-xe`, cross-edition: `mwse-only`. Reason: Engine prerequisite placeholder; no repository test evidence is recorded.
+- **MWSE** (`mwse`) — status: `planned`, engine: `mwse`, cross-edition: `mwse-only`. Reason: Engine prerequisite placeholder; no repository test evidence is recorded.
 - **Project Atlas** (`project-atlas`) — status: `planned`, engine: `mwse`, cross-edition: `equivalent-needed`. Reason: Initial candidate placeholder entry.
 - **Tamriel Data** (`tamriel-data`) — status: `planned`, engine: `mwse`, cross-edition: `equivalent-needed`. Reason: Initial candidate placeholder entry.
 
@@ -38,18 +41,18 @@ Manual intro text.
 
 ## Sixth House and Dream Contamination
 - **The Blight** (`the-blight`) — status: `planned`, engine: `mwse`, cross-edition: `mwse-only`. Reason: Initial candidate placeholder entry.
-- **Lucid Disturbing Dreams** (`lucid-disturbing-dreams`) — status: `planned`, engine: `mwse`, cross-edition: `equivalent-needed`. Reason: Initial candidate placeholder entry.
-- **Beware the Sixth House** (`beware-the-sixth-house`) — status: `planned`, engine: `mwse`, cross-edition: `equivalent-needed`. Reason: Initial candidate placeholder entry.
-- **Creeping Blight** (`creeping-blight`) — status: `planned`, engine: `mwse`, cross-edition: `equivalent-needed`. Reason: Initial candidate placeholder entry.
+- **Lucid Disturbing Dreams** (`lucid-disturbing-dreams`) — status: `planned`, engine: `mwse`, cross-edition: `equivalent-needed`. Reason: Planning placeholder linked to canonical sourcing metadata; not promoted or compatibility-tested.
+- **Beware the Sixth House** (`beware-the-sixth-house`) — status: `planned`, engine: `mwse`, cross-edition: `equivalent-needed`. Reason: Planning placeholder linked to canonical sourcing metadata; not promoted or compatibility-tested.
+- **Creeping Blight** (`creeping-blight`) — status: `planned`, engine: `mwse`, cross-edition: `equivalent-needed`. Reason: Planning placeholder linked to canonical sourcing metadata; not promoted or compatibility-tested.
 - **Ghastly Glowyfence** (`ghastly-glowyfence`) — status: `planned`, engine: `mwse`, cross-edition: `equivalent-needed`. Reason: Initial candidate placeholder entry.
 
 ## Soundscape and Silence
-- **Heartthrum** (`heartthrum`) — status: `planned`, engine: `mwse`, cross-edition: `mwse-only`. Reason: Initial candidate placeholder entry.
+- **Heartthrum** (`heartthrum`) — status: `planned`, engine: `mwse`, cross-edition: `mwse-only`. Reason: Planning placeholder linked to canonical sourcing metadata; not promoted or compatibility-tested.
 - **Cave Drips** (`cave-drips`) — status: `planned`, engine: `mwse`, cross-edition: `equivalent-needed`. Reason: Initial candidate placeholder entry.
 - **Atmospheric Sound Effects Expanded** (`atmospheric-sound-effects-expanded`) — status: `planned`, engine: `mwse`, cross-edition: `equivalent-needed`. Reason: Initial candidate placeholder entry.
 
 ## Travel, Pilgrimage, and Logistics
-- **The Dream is the Door** (`the-dream-is-the-door`) — status: `planned`, engine: `mwse`, cross-edition: `equivalent-needed`. Reason: Initial candidate placeholder entry.
+- **The Dream is the Door** (`the-dream-is-the-door`) — status: `planned`, engine: `mwse`, cross-edition: `equivalent-needed`. Reason: Planning placeholder linked to canonical sourcing metadata; not promoted or compatibility-tested.
 
 ## UI, Journals, and Player Perception
 - **UI Expansion** (`ui-expansion`) — status: `planned`, engine: `mwse`, cross-edition: `mwse-only`. Reason: Initial candidate placeholder entry.

--- a/ash-archive/editions/mwse/README.md
+++ b/ash-archive/editions/mwse/README.md
@@ -2,20 +2,32 @@
 
 **Engine target:** Classic Morrowind + MCP + MGE XE + MWSE
 
-**Tagline:** The dream notices you.
+**Tagline:** *The dream notices you.*
 
-## Edition identity
-Script-heavy, reactive, psychologically invasive dream horror.
+## Planned identity
+
+Sleeper targets reactive, configurable dream contamination and identity-fracture horror
+using MWSE-capable systems. This is a design target, not evidence that a script stack or
+working build exists.
 
 ## Current status
-Planning/scaffold only. Not installable yet. No final load order is defined.
 
-## What belongs in this edition
-- Mods and tools that reinforce this edition's engine strengths.
-- Atmosphere and systems aligned to Ash Archive design pillars.
-- Entries that are documented with notes and explicit verification status.
+Planning/control scaffold only. There is no installable build, verified engine/tool version
+set, final load order, completed test route, or end-to-end install result.
 
-## What does not belong in this edition
-- Direct crossover content from unrelated horror franchises.
-- Mods that undermine travel design, lore tone, or project stability.
-- Undocumented additions with unknown source or unclear behavior.
+## Edition boundary
+
+Sleeper may use MCP, MGE XE, and MWSE behavior that cannot or should not be forced into
+Pilgrim. A shared `source_reference` connects candidate provenance only; Sleeper-specific
+plugins, scripts, configuration, patches, performance, and testing remain separate.
+
+## Documentation
+
+- [`MODLIST.md`](MODLIST.md) — generated planning view, not an accepted list
+- [`docs/installation.md`](docs/installation.md) — installation blocker and planned MO2 boundary
+- [`docs/load-order-policy.md`](docs/load-order-policy.md) — load-order evidence needed
+- [`docs/testing-checklist.md`](docs/testing-checklist.md) — planned test gates
+- [`docs/known-issues.md`](docs/known-issues.md) — issue-recording policy
+- [`wabbajack/release-checklist.md`](wabbajack/release-checklist.md) — unchecked release gates
+
+Shared design constraints remain authoritative in the [`Project Bible`](../../PROJECT-BIBLE.md).

--- a/ash-archive/editions/mwse/docs/atmosphere-checklist.md
+++ b/ash-archive/editions/mwse/docs/atmosphere-checklist.md
@@ -1,3 +1,12 @@
-# Atmosphere Checklist
+# Sleeper Atmosphere Checklist
 
-Placeholder document for mwse edition.
+Use this as a design-review prompt, not proof of implementation.
+
+- [ ] Scripted dread follows readable quest, sleep, ritual, and location state.
+- [ ] Dream contamination escalates without generic jump-scare stacking.
+- [ ] Identity fracture remains Morrowind-native and evidence-led.
+- [ ] Systems are configurable, recoverable, and legible to the player.
+- [ ] Script, audio, visual, and survival pressure do not become chaotic or obscure quest state.
+- [ ] No OpenMW parity is claimed for MWSE-only behavior.
+
+Record the route, configuration, and evidence for each checked item.

--- a/ash-archive/editions/mwse/docs/installation.md
+++ b/ash-archive/editions/mwse/docs/installation.md
@@ -1,8 +1,15 @@
-# Installation
+# Sleeper Installation
 
-## External tools
+## Status: blocked
 
-### Mod Organizer 2
-- Required mod manager for MWSE edition scaffolding.
-- Source: https://github.com/ModOrganizer2/modorganizer
-- Configuration details are pending; see `mod-organizer-2/setup-notes.md`.
+No Sleeper Wabbajack installer, verified Morrowind/MCP/MGE XE/MWSE version set, package set,
+or reproducible install procedure exists. This page must not be used as installation instructions.
+
+Mod Organizer 2 is a planned external tool, but its version, acquisition method, and
+configuration are not verified. Current planning notes are in
+[`../mod-organizer-2/setup-notes.md`](../mod-organizer-2/setup-notes.md); those notes are not
+a completed setup guide.
+
+Before instructions can be published, record legal game prerequisites, exact tool versions,
+clean-install assumptions, download/disk requirements, installer inputs and output, MWSE/MGE
+XE configuration, and a successful clean-machine install result.

--- a/ash-archive/editions/mwse/docs/known-issues.md
+++ b/ash-archive/editions/mwse/docs/known-issues.md
@@ -1,3 +1,8 @@
-# Known Issues
+# Sleeper Known Issues
 
-Placeholder document for mwse edition.
+No validated Sleeper build has been tested, so the absence of listed defects is **not**
+evidence that there are no known issues.
+
+When testing begins, each issue must record severity, affected build/commit, MCP/MGE XE/MWSE
+versions, configuration, reproduction route, expected and actual behavior, workaround,
+status, and supporting logs. Source uncertainty is not an observed game defect.

--- a/ash-archive/editions/mwse/docs/load-order-policy.md
+++ b/ash-archive/editions/mwse/docs/load-order-policy.md
@@ -1,3 +1,10 @@
-# Load Order Policy
+# Sleeper Load-Order Policy
 
-Placeholder document for mwse edition.
+## Status: not established
+
+No final MO2 mod order or plugin load order exists. Manifest `priority` values are planning
+order within categories and are not proof of a working MO2/plugin order.
+
+A future policy must record left-pane asset precedence, plugin ordering, MCP/MGE XE/MWSE
+requirements, script conflicts, patch placement, external tool output, and test evidence.
+Do not copy Pilgrim order merely to create parity.

--- a/ash-archive/editions/mwse/docs/performance.md
+++ b/ash-archive/editions/mwse/docs/performance.md
@@ -1,3 +1,9 @@
-# Performance
+# Sleeper Performance
 
-Placeholder document for mwse edition.
+## Status: no benchmark evidence
+
+No performance target or benchmark result is recorded for a complete Sleeper build.
+
+Future results must identify hardware, operating system, game/MCP/MGE XE/MWSE versions,
+resolution and settings, script configuration, mod set, save state, route, sample duration,
+metric, and variance. Repository checks and upstream claims are not Sleeper benchmarks.

--- a/ash-archive/editions/mwse/docs/post-install.md
+++ b/ash-archive/editions/mwse/docs/post-install.md
@@ -1,3 +1,11 @@
-# Post Install
+# Sleeper Post-Install
 
-Placeholder document for mwse edition.
+## Status: blocked by installation evidence
+
+There is no verified Sleeper installation to configure or launch. Do not invent paths,
+profile settings, MCP options, MGE XE generation steps, MWSE configuration, or expected
+first-launch behavior.
+
+This page becomes actionable only after a clean install records profile selection, tool
+configuration, required user choices, first launch, save creation, smoke checks, and
+rollback/recovery steps.

--- a/ash-archive/editions/mwse/docs/testing-checklist.md
+++ b/ash-archive/editions/mwse/docs/testing-checklist.md
@@ -1,3 +1,12 @@
-# Testing Checklist
+# Sleeper Testing Checklist
 
-Placeholder document for mwse edition.
+All items are pending; none records a completed test.
+
+- [ ] Record a reproducible clean installation and exact MCP/MGE XE/MWSE/MO2 configuration.
+- [ ] Confirm startup, new game, save, load, quit, and relaunch behavior.
+- [ ] Run the shared routes in [`shared/test-routes.md`](../../../shared/test-routes.md).
+- [ ] Exercise dream, sleep-state, Corprus, Kogoruhn, Incarnate, and Red Mountain thresholds.
+- [ ] Check script load, configuration UI, event timing, conflicts, patches, audio, UI, and travel.
+- [ ] Record performance using the environment format in [`performance.md`](performance.md).
+- [ ] Log issues with build, reproduction, severity, and evidence.
+- [ ] Obtain human review before advancing any entry to `testing` or `accepted`.

--- a/ash-archive/editions/mwse/manifests/mods.control.meta
+++ b/ash-archive/editions/mwse/manifests/mods.control.meta
@@ -82,7 +82,7 @@ mods:
     patch_notes: "needs verification"
     testing_notes: "needs verification"
     decision_reason: "Initial candidate placeholder entry."
-    priority: 4
+    priority: 5
   - id: tamriel-data
     name: Tamriel Data
     category: Engine and Foundation
@@ -103,7 +103,7 @@ mods:
     patch_notes: "needs verification"
     testing_notes: "needs verification"
     decision_reason: "Initial candidate placeholder entry."
-    priority: 5
+    priority: 6
   - id: oaab-data
     name: OAAB_Data
     category: Architecture of Memory
@@ -133,6 +133,7 @@ mods:
     status: planned
     engine:
       - mwse
+    source_reference: the-dream-is-the-door
     source: "tbd"
     url: ""
     archive_name: ""
@@ -143,8 +144,8 @@ mods:
     load_after: []
     load_before: []
     patch_notes: "needs verification"
-    testing_notes: "needs verification"
-    decision_reason: "Initial candidate placeholder entry."
+    testing_notes: "Not tested; see the canonical source record for pending evidence."
+    decision_reason: "Planning placeholder linked to canonical sourcing metadata; not promoted or compatibility-tested."
     priority: 7
   - id: lucid-disturbing-dreams
     name: Lucid Disturbing Dreams
@@ -154,6 +155,7 @@ mods:
     status: planned
     engine:
       - mwse
+    source_reference: lucid-disturbing-dreams
     source: "tbd"
     url: ""
     archive_name: ""
@@ -164,8 +166,8 @@ mods:
     load_after: []
     load_before: []
     patch_notes: "needs verification"
-    testing_notes: "needs verification"
-    decision_reason: "Initial candidate placeholder entry."
+    testing_notes: "Not tested; see the canonical source record for pending evidence."
+    decision_reason: "Planning placeholder linked to canonical sourcing metadata; not promoted or compatibility-tested."
     priority: 8
   - id: beware-the-sixth-house
     name: Beware the Sixth House
@@ -175,6 +177,7 @@ mods:
     status: planned
     engine:
       - mwse
+    source_reference: beware-the-sixth-house
     source: "tbd"
     url: ""
     archive_name: ""
@@ -185,8 +188,8 @@ mods:
     load_after: []
     load_before: []
     patch_notes: "needs verification"
-    testing_notes: "needs verification"
-    decision_reason: "Initial candidate placeholder entry."
+    testing_notes: "Not tested; see the canonical source record for pending evidence."
+    decision_reason: "Planning placeholder linked to canonical sourcing metadata; not promoted or compatibility-tested."
     priority: 9
   - id: divine-dagoths
     name: Divine Dagoths
@@ -217,6 +220,7 @@ mods:
     status: planned
     engine:
       - mwse
+    source_reference: creeping-blight
     source: "tbd"
     url: ""
     archive_name: ""
@@ -227,8 +231,8 @@ mods:
     load_after: []
     load_before: []
     patch_notes: "needs verification"
-    testing_notes: "needs verification"
-    decision_reason: "Initial candidate placeholder entry."
+    testing_notes: "Not tested; see the canonical source record for pending evidence."
+    decision_reason: "Planning placeholder linked to canonical sourcing metadata; not promoted or compatibility-tested."
     priority: 11
   - id: cave-drips
     name: Cave Drips
@@ -424,7 +428,7 @@ mods:
     category: Engine and Foundation
     edition: mwse
     cross_edition_status: mwse-only
-    status: testing
+    status: planned
     engine:
       - mcp
     source: "tbd"
@@ -436,16 +440,16 @@ mods:
     conflicts: []
     load_after: []
     load_before: []
-    patch_notes: "needs verification"
-    testing_notes: "needs verification"
-    decision_reason: "Initial candidate placeholder entry."
-    priority: 1
+    patch_notes: "No integration or patch evidence is recorded."
+    testing_notes: "Not tested; version and integration evidence are still required."
+    decision_reason: "Engine prerequisite placeholder; no repository test evidence is recorded."
+    priority: 2
   - id: mge-xe
     name: MGE XE
     category: Engine and Foundation
     edition: mwse
     cross_edition_status: mwse-only
-    status: testing
+    status: planned
     engine:
       - mge-xe
     source: "tbd"
@@ -457,16 +461,16 @@ mods:
     conflicts: []
     load_after: []
     load_before: []
-    patch_notes: "needs verification"
-    testing_notes: "needs verification"
-    decision_reason: "Initial candidate placeholder entry."
-    priority: 2
+    patch_notes: "No integration or patch evidence is recorded."
+    testing_notes: "Not tested; version and integration evidence are still required."
+    decision_reason: "Engine prerequisite placeholder; no repository test evidence is recorded."
+    priority: 3
   - id: mwse
     name: MWSE
     category: Engine and Foundation
     edition: mwse
     cross_edition_status: mwse-only
-    status: testing
+    status: planned
     engine:
       - mwse
     source: "tbd"
@@ -478,10 +482,10 @@ mods:
     conflicts: []
     load_after: []
     load_before: []
-    patch_notes: "needs verification"
-    testing_notes: "needs verification"
-    decision_reason: "Initial candidate placeholder entry."
-    priority: 3
+    patch_notes: "No integration or patch evidence is recorded."
+    testing_notes: "Not tested; version and integration evidence are still required."
+    decision_reason: "Engine prerequisite placeholder; no repository test evidence is recorded."
+    priority: 4
   - id: ui-expansion
     name: UI Expansion
     category: UI, Journals, and Player Perception
@@ -511,6 +515,7 @@ mods:
     status: planned
     engine:
       - mwse
+    source_reference: ashfall
     source: "tbd"
     url: ""
     archive_name: ""
@@ -521,8 +526,8 @@ mods:
     load_after: []
     load_before: []
     patch_notes: "needs verification"
-    testing_notes: "needs verification"
-    decision_reason: "Initial candidate placeholder entry."
+    testing_notes: "Not tested; see the canonical source record for pending evidence."
+    decision_reason: "Planning placeholder linked to canonical sourcing metadata; not promoted or compatibility-tested."
     priority: 5
   - id: the-blight
     name: The Blight
@@ -553,6 +558,7 @@ mods:
     status: planned
     engine:
       - mwse
+    source_reference: heartthrum
     source: "tbd"
     url: ""
     archive_name: ""
@@ -563,8 +569,8 @@ mods:
     load_after: []
     load_before: []
     patch_notes: "needs verification"
-    testing_notes: "needs verification"
-    decision_reason: "Initial candidate placeholder entry."
+    testing_notes: "Not tested; see the canonical source record for pending evidence."
+    decision_reason: "Planning placeholder linked to canonical sourcing metadata; not promoted or compatibility-tested."
     priority: 7
   - id: kogoruhn-expanded
     name: Kogoruhn Expanded

--- a/ash-archive/editions/mwse/mod-organizer-2/profile-notes.md
+++ b/ash-archive/editions/mwse/mod-organizer-2/profile-notes.md
@@ -1,7 +1,11 @@
 # MO2 Profile Notes
 
-Scaffold phase: no production profile defined yet.
+## Status: no production profile
 
-## Dependencies
-- Profiles will be authored after MO2 acquisition from the upstream repo:
-  - https://github.com/ModOrganizer2/modorganizer
+No Sleeper MO2 profile, left-pane order, plugin order, tool registration, INI set, or archive
+state is recorded. Do not infer a profile from manifest priority values.
+
+A future profile record must identify the approved MO2 setup, exact manifest revision,
+enabled/disabled mods, separators, overwrite handling, executables, profile-local saves and
+INI policy, plugin ordering, generated outputs, and clean-launch/test evidence. Profile data
+must remain separate from machine-specific paths and unsupported binaries.

--- a/ash-archive/editions/mwse/mod-organizer-2/setup-notes.md
+++ b/ash-archive/editions/mwse/mod-organizer-2/setup-notes.md
@@ -1,10 +1,16 @@
 # MO2 Setup Notes
 
-Scaffold phase: no production setup configuration defined yet.
+## Status: blocked
 
-## Source
-- Upstream repo: https://github.com/ModOrganizer2/modorganizer
+Mod Organizer 2 is a planned Sleeper tool, but no version, acquisition method, instance
+layout, game path, or Wabbajack integration has been selected or tested. This page is not a
+setup procedure.
 
-## Acquisition
-- Clone the upstream repo only when a build pipeline or Wabbajack compilation step requires it.
-- Keep this control repository free of vendored MO2 binaries.
+The repository-recorded upstream project is
+[ModOrganizer2/modorganizer](https://github.com/ModOrganizer2/modorganizer). That link does
+not establish which release artifact or build method Sleeper will use.
+
+Before this page becomes actionable, record the approved MO2 version and acquisition path,
+instance mode, managed game path, downloads/mods/profiles locations, required executables,
+archive handling, Wabbajack compiler boundary, and a successful clean setup. Keep binaries
+and local machine paths out of this control repository.

--- a/ash-archive/editions/mwse/wabbajack/compiler-notes.md
+++ b/ash-archive/editions/mwse/wabbajack/compiler-notes.md
@@ -1,3 +1,11 @@
-# Compiler Notes
+# Sleeper Compiler Notes
 
-Scaffold phase: no production compiler profile yet.
+## Status: no production compiler profile
+
+No Wabbajack compiler inputs, approved MO2 profile, download set, directives, hashes, output
+artifact, or successful compile log are recorded for Sleeper. Planning manifests and generated
+Markdown are not compiler configuration.
+
+Future notes must identify approved manifest revision, legal acquisition paths, exact tool
+versions, compiler configuration, output, warnings, and clean-install result without
+inventing or redistributing unsupported artifacts.

--- a/ash-archive/editions/mwse/wabbajack/release-checklist.md
+++ b/ash-archive/editions/mwse/wabbajack/release-checklist.md
@@ -1,3 +1,13 @@
-# Release Checklist
+# Sleeper Release Checklist
 
-Scaffold phase only; release items to be defined after validation phase.
+Sleeper is not release-ready. Every item is pending and requires recorded evidence.
+
+- [ ] Human-approved release-candidate manifest with no unsupported status claims.
+- [ ] Source, package identity, licensing, and distribution blockers resolved or documented.
+- [ ] CI and generated-file checks pass at the release commit.
+- [ ] MO2 profile, compiler inputs, and reproducible output are recorded.
+- [ ] Clean end-to-end install succeeds on a supported environment.
+- [ ] MCP/MGE XE/MWSE configuration and script-stack behavior are reproducible.
+- [ ] Post-install, load-order, test-route, performance, and known-issues evidence is complete.
+- [ ] Support boundaries, rollback guidance, and release notes are published.
+- [ ] A human reviewer approves Sleeper release readiness.

--- a/ash-archive/editions/openmw/MODLIST.md
+++ b/ash-archive/editions/openmw/MODLIST.md
@@ -1,11 +1,14 @@
 # Modlist
 
-Manual intro text.
+This is a generated **planning view**, not an installable, tested, or accepted modlist.
+Edit the edition manifest and run `python tools/generate_modlist_markdown.py`; do not edit
+content between the generated markers. Status describes the edition record only, and a
+canonical source link does not itself prove compatibility or promotion.
 
 <!-- GENERATED-CONTENT:START -->
 ## Architecture of Memory
 - **OAAB_Data** (`oaab-data`) — status: `planned`, engine: `openmw`, cross-edition: `equivalent-needed`. Reason: Initial candidate placeholder entry.
-- **Kogoruhn - Extinct City of Ash and Sulfur** (`kogoruhn-extinct-city-of-ash-and-sulfur`) — status: `planned`, engine: `openmw`, cross-edition: `openmw-only`. Reason: Initial candidate placeholder entry.
+- **Kogoruhn - Extinct City of Ash and Sulfur** (`kogoruhn-extinct-city-of-ash-and-sulfur`) — status: `planned`, engine: `openmw`, cross-edition: `openmw-only`. Reason: Planning placeholder linked to canonical sourcing metadata; not promoted or compatibility-tested.
 - **Caldera Mine Expanded** (`caldera-mine-expanded`) — status: `planned`, engine: `openmw`, cross-edition: `equivalent-needed`. Reason: Initial candidate placeholder entry.
 
 ## Archives, Evidence, and Retrospective Dread
@@ -20,7 +23,6 @@ Manual intro text.
 
 ## Bug Fixes and Stability
 - **Expansion Delay** (`expansion-delay`) — status: `planned`, engine: `openmw`, cross-edition: `equivalent-needed`. Reason: Initial candidate placeholder entry.
-- **It Beats OpenMW** (`it-beats-openmw`) — status: `planned`, engine: `openmw`, cross-edition: `openmw-only`. Reason: Initial candidate placeholder entry.
 
 ## Dwemer Tonal Ruins
 - **Dwemer Mesh Improvement** (`dwemer-mesh-improvement`) — status: `planned`, engine: `openmw`, cross-edition: `equivalent-needed`. Reason: Initial candidate placeholder entry.
@@ -28,7 +30,7 @@ Manual intro text.
 
 ## Engine and Foundation
 - **Patch for Purists** (`patch-for-purists`) — status: `planned`, engine: `openmw`, cross-edition: `equivalent-needed`. Reason: Initial candidate placeholder entry.
-- **OpenMW** (`openmw`) — status: `testing`, engine: `openmw`, cross-edition: `openmw-only`. Reason: Initial candidate placeholder entry.
+- **OpenMW** (`openmw`) — status: `planned`, engine: `openmw`, cross-edition: `openmw-only`. Reason: Engine prerequisite placeholder; no repository test evidence is recorded.
 - **Project Atlas** (`project-atlas`) — status: `planned`, engine: `openmw`, cross-edition: `equivalent-needed`. Reason: Initial candidate placeholder entry.
 - **Tamriel Data** (`tamriel-data`) — status: `planned`, engine: `openmw`, cross-edition: `equivalent-needed`. Reason: Initial candidate placeholder entry.
 
@@ -36,18 +38,19 @@ Manual intro text.
 - **Red Wisdom - An Ashlander Prophecy** (`red-wisdom-an-ashlander-prophecy`) — status: `planned`, engine: `openmw`, cross-edition: `equivalent-needed`. Reason: Initial candidate placeholder entry.
 
 ## Sixth House and Dream Contamination
-- **Lucid Disturbing Dreams** (`lucid-disturbing-dreams`) — status: `planned`, engine: `openmw`, cross-edition: `equivalent-needed`. Reason: Initial candidate placeholder entry.
-- **Beware the Sixth House** (`beware-the-sixth-house`) — status: `planned`, engine: `openmw`, cross-edition: `equivalent-needed`. Reason: Initial candidate placeholder entry.
-- **Creeping Blight** (`creeping-blight`) — status: `planned`, engine: `openmw`, cross-edition: `equivalent-needed`. Reason: Initial candidate placeholder entry.
+- **Lucid Disturbing Dreams** (`lucid-disturbing-dreams`) — status: `planned`, engine: `openmw`, cross-edition: `equivalent-needed`. Reason: Planning placeholder linked to canonical sourcing metadata; not promoted or compatibility-tested.
+- **Beware the Sixth House** (`beware-the-sixth-house`) — status: `planned`, engine: `openmw`, cross-edition: `equivalent-needed`. Reason: Planning placeholder linked to canonical sourcing metadata; not promoted or compatibility-tested.
+- **Creeping Blight** (`creeping-blight`) — status: `planned`, engine: `openmw`, cross-edition: `equivalent-needed`. Reason: Planning placeholder linked to canonical sourcing metadata; not promoted or compatibility-tested.
 - **Ghastly Glowyfence** (`ghastly-glowyfence`) — status: `planned`, engine: `openmw`, cross-edition: `equivalent-needed`. Reason: Initial candidate placeholder entry.
 
 ## Soundscape and Silence
+- **It Beats OpenMW** (`it-beats-openmw`) — status: `planned`, engine: `openmw`, cross-edition: `openmw-only`. Reason: Planning placeholder linked to canonical sourcing metadata; not promoted or compatibility-tested.
 - **MUSE Music Expansion - Sixth House** (`muse-music-expansion-sixth-house`) — status: `planned`, engine: `openmw`, cross-edition: `openmw-only`. Reason: Initial candidate placeholder entry.
 - **Cave Drips** (`cave-drips`) — status: `planned`, engine: `openmw`, cross-edition: `equivalent-needed`. Reason: Initial candidate placeholder entry.
 - **Atmospheric Sound Effects Expanded** (`atmospheric-sound-effects-expanded`) — status: `planned`, engine: `openmw`, cross-edition: `equivalent-needed`. Reason: Initial candidate placeholder entry.
 
 ## Travel, Pilgrimage, and Logistics
-- **The Dream is the Door** (`the-dream-is-the-door`) — status: `planned`, engine: `openmw`, cross-edition: `equivalent-needed`. Reason: Initial candidate placeholder entry.
+- **The Dream is the Door** (`the-dream-is-the-door`) — status: `planned`, engine: `openmw`, cross-edition: `equivalent-needed`. Reason: Planning placeholder linked to canonical sourcing metadata; not promoted or compatibility-tested.
 - **S3maphore** (`s3maphore`) — status: `planned`, engine: `openmw`, cross-edition: `openmw-only`. Reason: Initial candidate placeholder entry.
 
 ## UI, Journals, and Player Perception

--- a/ash-archive/editions/openmw/README.md
+++ b/ash-archive/editions/openmw/README.md
@@ -2,20 +2,33 @@
 
 **Engine target:** OpenMW
 
-**Tagline:** The island remembers.
+**Tagline:** *The island remembers.*
 
-## Edition identity
-Stable, atmospheric, long-play-focused pilgrimage horror.
+## Planned identity
+
+Pilgrim targets stable long-play traversal and environmental pilgrimage horror through
+weather, distance, documents, tomb architecture, and retrospective dread. This is a design
+target, not a current stability claim.
 
 ## Current status
-Planning/scaffold only. Not installable yet. No final load order is defined.
 
-## What belongs in this edition
-- Mods and tools that reinforce this edition's engine strengths.
-- Atmosphere and systems aligned to Ash Archive design pillars.
-- Entries that are documented with notes and explicit verification status.
+Planning/control scaffold only. There is no installable build, verified OpenMW version,
+final load order, completed test route, or end-to-end install result.
 
-## What does not belong in this edition
-- Direct crossover content from unrelated horror franchises.
-- Mods that undermine travel design, lore tone, or project stability.
-- Undocumented additions with unknown source or unclear behavior.
+## Edition boundary
+
+Pilgrim favors OpenMW-native, readable, long-play systems and environmental pressure. It
+does not inherit Sleeper's MWSE scripts or acceptance decisions. A shared
+`source_reference` connects candidate provenance only; all OpenMW behavior, patching,
+testing, and ordering still require Pilgrim evidence.
+
+## Documentation
+
+- [`MODLIST.md`](MODLIST.md) — generated planning view, not an accepted list
+- [`docs/installation.md`](docs/installation.md) — installation blocker
+- [`docs/load-order-policy.md`](docs/load-order-policy.md) — load-order evidence needed
+- [`docs/testing-checklist.md`](docs/testing-checklist.md) — planned test gates
+- [`docs/known-issues.md`](docs/known-issues.md) — issue-recording policy
+- [`wabbajack/release-checklist.md`](wabbajack/release-checklist.md) — unchecked release gates
+
+Shared design constraints remain authoritative in the [`Project Bible`](../../PROJECT-BIBLE.md).

--- a/ash-archive/editions/openmw/docs/atmosphere-checklist.md
+++ b/ash-archive/editions/openmw/docs/atmosphere-checklist.md
@@ -1,3 +1,12 @@
-# Atmosphere Checklist
+# Pilgrim Atmosphere Checklist
 
-Placeholder document for openmw edition.
+Use this as a design-review prompt, not proof of implementation.
+
+- [ ] Weather, distance, documents, tombs, and silence carry dread without scripted jump events.
+- [ ] Travel preserves pilgrimage friction and remains readable over long play.
+- [ ] Evidence precedes explanation at major Nerevarine thresholds.
+- [ ] Architecture and landscape remain recognizably Morrowind-native.
+- [ ] Visual and audio layers do not erase navigation, dialogue, or quest readability.
+- [ ] No MWSE-only behavior is assumed or simulated through unsupported parity claims.
+
+Record the route and evidence for each checked item.

--- a/ash-archive/editions/openmw/docs/installation.md
+++ b/ash-archive/editions/openmw/docs/installation.md
@@ -1,3 +1,11 @@
-# Installation
+# Pilgrim Installation
 
-Placeholder document for openmw edition.
+## Status: blocked
+
+No Pilgrim Wabbajack installer, verified OpenMW version, package set, or reproducible install
+procedure exists. This page must not be used as installation instructions.
+
+Before instructions can be published, record the supported game source, OpenMW build,
+download and disk requirements, clean-install prerequisites, installer inputs, expected
+output, launch configuration, and a successful clean-machine install result. Unknowns must
+remain explicit rather than being inferred from candidate metadata.

--- a/ash-archive/editions/openmw/docs/known-issues.md
+++ b/ash-archive/editions/openmw/docs/known-issues.md
@@ -1,3 +1,9 @@
-# Known Issues
+# Pilgrim Known Issues
 
-Placeholder document for openmw edition.
+No validated Pilgrim build has been tested, so the absence of listed defects is **not**
+evidence that there are no known issues.
+
+When testing begins, each issue must record severity, affected build/commit, OpenMW version,
+reproduction route, expected and actual behavior, workaround, status, and supporting logs or
+screenshots. Source uncertainty and untested compatibility belong in manifests or sourcing
+records rather than being mislabeled as observed game defects.

--- a/ash-archive/editions/openmw/docs/load-order-policy.md
+++ b/ash-archive/editions/openmw/docs/load-order-policy.md
@@ -1,3 +1,10 @@
-# Load Order Policy
+# Pilgrim Load-Order Policy
 
-Placeholder document for openmw edition.
+## Status: not established
+
+No final OpenMW content-file or data-directory order exists. Manifest `priority` values are
+planning order within categories and are not proof of a working plugin load order.
+
+A future policy must record OpenMW-specific data directory precedence, plugin ordering,
+groundcover handling where applicable, dependency and conflict evidence, patch placement,
+tool output, and test-route results. Do not copy Sleeper ordering merely to create parity.

--- a/ash-archive/editions/openmw/docs/performance.md
+++ b/ash-archive/editions/openmw/docs/performance.md
@@ -1,3 +1,9 @@
-# Performance
+# Pilgrim Performance
 
-Placeholder document for openmw edition.
+## Status: no benchmark evidence
+
+No performance target or benchmark result is recorded for a complete Pilgrim build.
+
+Future results must identify hardware, operating system, OpenMW build, resolution, renderer
+and graphics settings, mod/asset set, save state, route, sample duration, metric, and observed
+variance. Repository validation and upstream performance claims are not Pilgrim benchmarks.

--- a/ash-archive/editions/openmw/docs/post-install.md
+++ b/ash-archive/editions/openmw/docs/post-install.md
@@ -1,3 +1,10 @@
-# Post Install
+# Pilgrim Post-Install
 
-Placeholder document for openmw edition.
+## Status: blocked by installation evidence
+
+There is no verified Pilgrim installation to configure or launch. Do not invent OpenMW paths,
+settings, content registrations, or expected first-launch behavior.
+
+This page can become actionable only after a clean install records configuration import,
+data directories, content files, required user choices, first launch, save creation, smoke
+checks, and rollback/recovery steps.

--- a/ash-archive/editions/openmw/docs/testing-checklist.md
+++ b/ash-archive/editions/openmw/docs/testing-checklist.md
@@ -1,3 +1,12 @@
-# Testing Checklist
+# Pilgrim Testing Checklist
 
-Placeholder document for openmw edition.
+All items are pending; none records a completed test.
+
+- [ ] Record a reproducible clean installation and exact OpenMW configuration.
+- [ ] Confirm startup, new game, save, load, quit, and relaunch behavior.
+- [ ] Run the shared routes in [`shared/test-routes.md`](../../../shared/test-routes.md).
+- [ ] Exercise main-quest dream, Corprus, Kogoruhn, Incarnate, and Red Mountain thresholds.
+- [ ] Check data-directory precedence, plugins, patches, weather, sound, UI, and travel systems.
+- [ ] Record performance using the environment format in [`performance.md`](performance.md).
+- [ ] Log issues with build, reproduction, severity, and evidence.
+- [ ] Obtain human review before advancing any entry to `testing` or `accepted`.

--- a/ash-archive/editions/openmw/manifests/mods.control.meta
+++ b/ash-archive/editions/openmw/manifests/mods.control.meta
@@ -133,6 +133,7 @@ mods:
     status: planned
     engine:
       - openmw
+    source_reference: the-dream-is-the-door
     source: "tbd"
     url: ""
     archive_name: ""
@@ -143,8 +144,8 @@ mods:
     load_after: []
     load_before: []
     patch_notes: "needs verification"
-    testing_notes: "needs verification"
-    decision_reason: "Initial candidate placeholder entry."
+    testing_notes: "Not tested; see the canonical source record for pending evidence."
+    decision_reason: "Planning placeholder linked to canonical sourcing metadata; not promoted or compatibility-tested."
     priority: 7
   - id: lucid-disturbing-dreams
     name: Lucid Disturbing Dreams
@@ -154,6 +155,7 @@ mods:
     status: planned
     engine:
       - openmw
+    source_reference: lucid-disturbing-dreams
     source: "tbd"
     url: ""
     archive_name: ""
@@ -164,8 +166,8 @@ mods:
     load_after: []
     load_before: []
     patch_notes: "needs verification"
-    testing_notes: "needs verification"
-    decision_reason: "Initial candidate placeholder entry."
+    testing_notes: "Not tested; see the canonical source record for pending evidence."
+    decision_reason: "Planning placeholder linked to canonical sourcing metadata; not promoted or compatibility-tested."
     priority: 8
   - id: beware-the-sixth-house
     name: Beware the Sixth House
@@ -175,6 +177,7 @@ mods:
     status: planned
     engine:
       - openmw
+    source_reference: beware-the-sixth-house
     source: "tbd"
     url: ""
     archive_name: ""
@@ -185,8 +188,8 @@ mods:
     load_after: []
     load_before: []
     patch_notes: "needs verification"
-    testing_notes: "needs verification"
-    decision_reason: "Initial candidate placeholder entry."
+    testing_notes: "Not tested; see the canonical source record for pending evidence."
+    decision_reason: "Planning placeholder linked to canonical sourcing metadata; not promoted or compatibility-tested."
     priority: 9
   - id: divine-dagoths
     name: Divine Dagoths
@@ -217,6 +220,7 @@ mods:
     status: planned
     engine:
       - openmw
+    source_reference: creeping-blight
     source: "tbd"
     url: ""
     archive_name: ""
@@ -227,8 +231,8 @@ mods:
     load_after: []
     load_before: []
     patch_notes: "needs verification"
-    testing_notes: "needs verification"
-    decision_reason: "Initial candidate placeholder entry."
+    testing_notes: "Not tested; see the canonical source record for pending evidence."
+    decision_reason: "Planning placeholder linked to canonical sourcing metadata; not promoted or compatibility-tested."
     priority: 11
   - id: cave-drips
     name: Cave Drips
@@ -424,27 +428,6 @@ mods:
     category: Engine and Foundation
     edition: openmw
     cross_edition_status: openmw-only
-    status: testing
-    engine:
-      - openmw
-    source: "tbd"
-    url: ""
-    archive_name: ""
-    version: ""
-    plugin_files: []
-    requires: []
-    conflicts: []
-    load_after: []
-    load_before: []
-    patch_notes: "needs verification"
-    testing_notes: "needs verification"
-    decision_reason: "Initial candidate placeholder entry."
-    priority: 1
-  - id: it-beats-openmw
-    name: It Beats OpenMW
-    category: Bug Fixes and Stability
-    edition: openmw
-    cross_edition_status: openmw-only
     status: planned
     engine:
       - openmw
@@ -457,10 +440,32 @@ mods:
     conflicts: []
     load_after: []
     load_before: []
-    patch_notes: "needs verification"
-    testing_notes: "needs verification"
-    decision_reason: "Initial candidate placeholder entry."
+    patch_notes: "No integration or patch evidence is recorded."
+    testing_notes: "Not tested; version and integration evidence are still required."
+    decision_reason: "Engine prerequisite placeholder; no repository test evidence is recorded."
     priority: 2
+  - id: it-beats-openmw
+    name: It Beats OpenMW
+    category: Soundscape and Silence
+    edition: openmw
+    cross_edition_status: openmw-only
+    status: planned
+    engine:
+      - openmw
+    source_reference: it-beats-openmw
+    source: "tbd"
+    url: ""
+    archive_name: ""
+    version: ""
+    plugin_files: []
+    requires: []
+    conflicts: []
+    load_after: []
+    load_before: []
+    patch_notes: "needs verification"
+    testing_notes: "Not tested; see the canonical source record for pending evidence."
+    decision_reason: "Planning placeholder linked to canonical sourcing metadata; not promoted or compatibility-tested."
+    priority: 7
   - id: true-nights-and-darkness
     name: True Nights and Darkness
     category: Ash, Weather, and Distance
@@ -532,6 +537,7 @@ mods:
     status: planned
     engine:
       - openmw
+    source_reference: kogoruhn-extinct-city-of-ash-and-sulfur
     source: "tbd"
     url: ""
     archive_name: ""
@@ -542,9 +548,9 @@ mods:
     load_after: []
     load_before: []
     patch_notes: "needs verification"
-    testing_notes: "needs verification"
-    decision_reason: "Initial candidate placeholder entry."
-    priority: 6
+    testing_notes: "Not tested; see the canonical source record for pending evidence."
+    decision_reason: "Planning placeholder linked to canonical sourcing metadata; not promoted or compatibility-tested."
+    priority: 7
   - id: s3maphore
     name: S3maphore
     category: Travel, Pilgrimage, and Logistics
@@ -565,7 +571,7 @@ mods:
     patch_notes: "needs verification"
     testing_notes: "needs verification"
     decision_reason: "Initial candidate placeholder entry."
-    priority: 7
+    priority: 8
   - id: muse-music-expansion-sixth-house
     name: MUSE Music Expansion - Sixth House
     category: Soundscape and Silence

--- a/ash-archive/editions/openmw/wabbajack/compiler-notes.md
+++ b/ash-archive/editions/openmw/wabbajack/compiler-notes.md
@@ -1,3 +1,11 @@
-# Compiler Notes
+# Pilgrim Compiler Notes
 
-Scaffold phase: no production compiler profile yet.
+## Status: no production compiler profile
+
+No Wabbajack compiler inputs, download set, directives, hashes, output artifact, or successful
+compile log are recorded for Pilgrim. Candidate manifests and generated Markdown are not a
+compiler configuration.
+
+Future notes must identify the exact approved manifest revision, legal acquisition path,
+OpenMW setup boundary, compiler version/configuration, output, warnings, and clean-install
+result without inventing or redistributing unsupported source artifacts.

--- a/ash-archive/editions/openmw/wabbajack/release-checklist.md
+++ b/ash-archive/editions/openmw/wabbajack/release-checklist.md
@@ -1,3 +1,12 @@
-# Release Checklist
+# Pilgrim Release Checklist
 
-Scaffold phase only; release items to be defined after validation phase.
+Pilgrim is not release-ready. Every item is pending and requires recorded evidence.
+
+- [ ] Human-approved release-candidate manifest with no unsupported status claims.
+- [ ] Source, package identity, licensing, and distribution blockers resolved or documented.
+- [ ] CI and generated-file checks pass at the release commit.
+- [ ] Compiler inputs and reproducible output are recorded.
+- [ ] Clean end-to-end install succeeds on a supported environment.
+- [ ] Post-install, load-order, test-route, performance, and known-issues evidence is complete.
+- [ ] Support boundaries, rollback guidance, and release notes are published.
+- [ ] A human reviewer approves Pilgrim release readiness.

--- a/ash-archive/pyproject.toml
+++ b/ash-archive/pyproject.toml
@@ -1,3 +1,7 @@
+[build-system]
+requires = ["setuptools>=69"]
+build-backend = "setuptools.build_meta"
+
 [project]
 name = "ash-archive-control"
 version = "0.1.0"
@@ -17,6 +21,10 @@ dev = [
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 
+[tool.setuptools]
+packages = ["tools", "tools.lib"]
+py-modules = []
+
 [tool.ruff]
 line-length = 100
 target-version = "py311"
@@ -26,6 +34,3 @@ select = ["E4", "E7", "E9", "F", "I", "B", "UP"]
 
 [tool.black]
 line-length = 100
-
-[tool.setuptools]
-py-modules = []

--- a/ash-archive/shared/design-rules.md
+++ b/ash-archive/shared/design-rules.md
@@ -1,3 +1,22 @@
 # Shared Design Rules
 
-Keep both editions aligned on pillars while allowing engine-specific implementation.
+The [`Project Bible`](../PROJECT-BIBLE.md) is authoritative. Shared planning keeps both
+editions aligned on its themes while allowing engine-native implementations.
+
+## Shared constraints
+
+- Build horror from Morrowind's prophecy, history, landscape, factions, and mechanics.
+- Present evidence before explanation.
+- Preserve pilgrimage friction; convenience and survival systems require design review.
+- Exclude direct horror-franchise crossovers, generic jump scares, Skyrimification, and
+  anime-style face direction.
+- Record uncertainty rather than inventing source, compatibility, or test facts.
+
+## Edition independence
+
+Shared provenance is not shared acceptance. Pilgrim and Sleeper may select different mods,
+patches, settings, and load-order relationships. A difference needs an edition rationale,
+but different mod counts or implementations are not defects by themselves.
+
+Human review is required for design-bible exceptions, forced parity decisions, and changes
+that redefine either edition's identity.

--- a/ash-archive/shared/mo2-download-meta-sidecars.md
+++ b/ash-archive/shared/mo2-download-meta-sidecars.md
@@ -1,17 +1,22 @@
 # MO2 Download `.meta` Sidecars vs Internal Control Metadata
 
-## Separation of artifact types
+## Separate artifact classes
 
-- MO2/Wabbajack download `.meta` sidecars are a **separate artifact class** from internal project metadata.
-- Internal `.control.meta` files are YAML-formatted **internal control metadata** used by repository tooling and are **not MO2 download sidecars**.
+- Native MO2/Wabbajack download `.meta` sidecars belong to downloaded archives and use the
+  format expected by Mod Organizer 2.
+- Repository `.control.meta` files are YAML internal control data used by Ash Archive tools;
+  they are not MO2 download sidecars.
+- Renaming or serializing internal YAML as `.meta` does not make it a native MO2 sidecar.
 
-## Source of native sidecars
+## Native sidecar evidence
 
-- Native MO2 download sidecar `.meta` files should be imported from a real Mod Organizer 2 downloads directory when available.
-- Do **not** synthesize native MO2 `.meta` files unless the exact required fields are known and verified.
+Import native sidecars from a real MO2 downloads directory only when the exact artifact and
+fields are available. Do not synthesize Nexus file IDs, hashes, file sizes, archive names, or
+other download metadata.
 
-## Data integrity guardrails
+The repository-root [`modlist.txt`](../../modlist.txt) is an imported inventory snapshot. It
+is not a complete source of native sidecar data, and disabled rows remain evidence rather
+than deletion candidates. Local paths recorded in imported metadata describe the snapshot;
+they are not portable acquisition instructions or verified archive identities.
 
-- Do **not** invent Nexus file IDs, archive hashes, file sizes, or other download metadata.
-- `modlist.txt` is a source inventory, **not** a complete source of MO2 download sidecar metadata.
-- Disabled rows in `modlist.txt` are evidence and must remain preserved.
+See [`mod-meta-schema.md`](mod-meta-schema.md) for internal field ownership.

--- a/ash-archive/shared/mod-evaluation-rubric.md
+++ b/ash-archive/shared/mod-evaluation-rubric.md
@@ -1,3 +1,25 @@
 # Mod Evaluation Rubric
 
-Score candidate fit by atmosphere, technical risk, conflict profile, and maintenance burden.
+Use this rubric to organize evidence for human review. It does not automatically accept or
+reject a candidate.
+
+| Dimension | Questions to record |
+|---|---|
+| Thematic fit | Which project pillar does it reinforce? Does it remain Morrowind-native? |
+| Engine fit | Which edition supports it, and what requirement or limitation establishes that? |
+| Technical risk | What scripts, assets, cells, records, or external tools can conflict? |
+| Compatibility evidence | What documentation or in-game route was checked, in which edition and configuration? |
+| Performance | What hardware, settings, location, duration, and metric were observed? |
+| Maintenance | How stable are the source, package identity, patch burden, and update path? |
+| Player experience | Does it preserve pilgrimage friction, readability, accessibility, and configurability? |
+
+## Evaluation outcomes
+
+- Keep `candidate` when evidence is insufficient to begin a decision.
+- Use `under-review` while evidence is being assembled.
+- Use `promoted`, `rejected`, or `superseded` only after human review and retain the rationale.
+- Evaluate Pilgrim and Sleeper independently; upstream engine tags are not substitutes for
+  an edition test.
+
+Record the test route, environment, result, reviewer, and unresolved risks. A verified source
+URL establishes provenance, not compatibility.

--- a/ash-archive/shared/mod-meta-schema.md
+++ b/ash-archive/shared/mod-meta-schema.md
@@ -1,147 +1,82 @@
-# `.control.meta` File Schema for `modlist.txt` Conversion
+# Control Metadata and Manifest Schema
 
-This document defines the canonical schema for per-mod metadata files in this repository.
+Ash Archive uses YAML `.control.meta` files as internal control data. They are not native
+MO2 download sidecars. This document describes field ownership and the contracts enforced by
+repository tools; the Python validators remain the executable specification.
 
-## Purpose
+## Metadata layers
 
-Internal control metadata `.control.meta` files provide deterministic, machine-readable metadata converted from `modlist.txt` rows and augmented with project triage fields. These internal control records are **not MO2 download sidecars** and must not be treated as native MO2/Wabbajack download metadata.
-
-## File format and naming
-
-- Files use the `.meta` extension (this schema specifically uses `.control.meta`).
-- Content remains YAML-structured metadata.
-- Naming pattern: `<slug>-<source_id>.control.meta`
-  - For Nexus-backed rows, `source_id` is the numeric `nexus_id`.
-  - For non-Nexus rows (`Unmanaged:*`, `DLC:*`, and rows without a Nexus ID), use `local`.
-
-Examples:
-
-- `the-dream-is-the-door-47423.control.meta`
-- `beware-the-sixth-house-46036.control.meta`
-- `unmanaged-siege-at-firemoth-local.control.meta`
-- `dlc-tribunal-local.control.meta`
-
-## Slug normalization rules
-
-Build `<slug>` from `mod_name` using the following deterministic normalization:
-
-1. Trim leading/trailing whitespace.
-2. Convert to lowercase.
-3. Convert apostrophes (`'`, `’`) to nothing.
-4. Convert underscores (`_`) and all whitespace runs to a single hyphen (`-`).
-5. Convert any punctuation other than hyphen to a separator, then collapse repeated separators to one hyphen.
-6. Remove leading/trailing hyphens.
-
-### Normalization examples
-
-- `Skies .IV` -> `skies-iv`
-- `Starfire's npc Additions - Danae's Edits and Fixes` -> `starfires-npc-additions-danaes-edits-and-fixes`
-- `Better_Clothes` -> `better-clothes`
-
-## Canonical schema
-
-Each file must contain the following top-level keys:
-
-```yaml
-schema_version: 1
-slug: string
-kind: nexus | unmanaged | dlc | local
-source:
-  mod_name: string
-  nexus_id: integer | null
-  nexus_url: string
-  archive_filename: string
-  version: string
-  install_date: string   # ISO-8601 UTC preferred, e.g. 2025-03-25T19:19:53Z
-  status: enabled | disabled
-project:
-  edition_target: openmw | mwse | both | undecided
-  category: string
-  confidence: low | medium | high
-  notes: string
-```
-
-## `kind` semantics and unmanaged representation
-
-Use `kind` to distinguish rows with different source guarantees:
-
-- `nexus`: Standard Nexus-backed row (`nexus_id > 0` and non-empty Nexus URL).
-- `unmanaged`: Row where `mod_name` starts with `Unmanaged:`.
-- `dlc`: Row where `mod_name` starts with `DLC:`.
-- `local`: Any non-Nexus row that is neither `Unmanaged:` nor `DLC:`.
-
-### Differences from Nexus-backed entries
-
-For `unmanaged`, `dlc`, and `local` rows:
-
-- `source.nexus_id` must be `null`.
-- `source.nexus_url` is `""`.
-- `source.archive_filename` may be empty when not available.
-- `source.version` should preserve `modlist.txt` value; if absent, use `""`.
-
-For `nexus` rows:
-
-- `source.nexus_id` must be the numeric ID from `modlist.txt`.
-- `source.nexus_url` should be the direct Nexus mod URL from `modlist.txt`.
-
-## Field mapping table (`modlist.txt` -> `.control.meta`)
-
-| `modlist.txt` column | `.control.meta` target | Mapping rule |
+| File family | Top-level shape | Responsibility |
 |---|---|---|
-| `#Mod_Name` | `source.mod_name` | Copy as-is. |
-| `#Nexus_ID` | `source.nexus_id` | If value > 0, copy integer; otherwise `null`. |
-| `#Mod_Nexus_URL` | `source.nexus_url` | Copy as-is; empty for non-Nexus rows. |
-| `#Download_File_Name` | `source.archive_filename` | Copy as-is (full path allowed). |
-| `#Mod_Version` | `source.version` | Copy as-is. |
-| `#Install_Date` | `source.install_date` | Convert `YYYY/MM/DD HH:MM:SS` to ISO-8601 UTC (`YYYY-MM-DDTHH:MM:SSZ`) when possible. |
-| `#Mod_Status` | `source.status` | `+` -> `enabled`; `-` -> `disabled`. |
-| `#Primary_Category` | `project.category` | Copy category text; if empty, use `uncategorized`. |
-| *(derived)* | `slug` | Normalize from `source.mod_name` using slug rules above. |
-| *(derived)* | `kind` | `Unmanaged:*` -> `unmanaged`; `DLC:*` -> `dlc`; Nexus-backed -> `nexus`; else `local`. |
-| *(project input)* | `project.edition_target` | Required manual/project classification. |
-| *(project input)* | `project.confidence` | Required manual/project confidence (`low|medium|high`). |
-| *(project input)* | `project.notes` | Required manual/project notes. |
+| `shared/sourced-mods.control.meta` | `sourced_candidates:` list | Canonical candidate identity, provenance, source evidence, uncertainty, and candidate-review state. |
+| `editions/*/manifests/mods.control.meta` | `mods:` list | Edition-specific selection, engine, plugin, patch, test, conflict, dependency, and ordering data. |
+| `shared/source-triage.control.meta` | `source_triage:` mapping | Blocking identity, package, and distribution questions from imported inventory. |
+| `shared/source-package-meta.control.meta` | `multi_package_sources:` list | Parent source pages and child package evidence. |
+| `editions/*/MODLIST.md` | generated Markdown section | Derived planning view; not canonical metadata. |
 
-## Minimal examples
+The repository-root [`modlist.txt`](../../modlist.txt) is an inventory snapshot, not an
+edition manifest or a complete MO2 download-sidecar source.
 
-### Nexus-backed entry
+## Canonical source records
 
-```yaml
-schema_version: 1
-slug: the-dream-is-the-door
-kind: nexus
-source:
-  mod_name: The Dream is the Door
-  nexus_id: 47423
-  nexus_url: https://www.nexusmods.com/morrowind/mods/47423
-  archive_filename: The Dream is the Door-47423-1-3-1655842474.7z
-  version: 1.3.0.0
-  install_date: 2025-03-29T12:59:31Z
-  status: enabled
-project:
-  edition_target: both
-  category: Immersion
-  confidence: medium
-  notes: Candidate aligns with dream pillar; pending in-engine verification.
-```
+Each sourced candidate has a stable lowercase kebab-case `id`. The source layer owns:
 
-### Unmanaged entry
+- `source_type`, `source_url`, `source_confidence`, and `evidence_notes`;
+- candidate identity and thematic/risk notes;
+- `candidate_status`, review fields, intended editions, compatibility status, and promotion target;
+- `related_manifest_ids`, the reverse links to edition entries.
 
-```yaml
-schema_version: 1
-slug: unmanaged-siege-at-firemoth
-kind: unmanaged
-source:
-  mod_name: "Unmanaged: Siege at Firemoth"
-  nexus_id: null
-  nexus_url: ""
-  archive_filename: ""
-  version: ""
-  install_date: 2026-01-13T23:38:37Z
-  status: enabled
-project:
-  edition_target: undecided
-  category: uncategorized
-  confidence: low
-  notes: Base content not sourced from Nexus row metadata.
-```
+Candidate status values are `candidate`, `under-review`, `promoted`, `rejected`, and
+`superseded`. Source confidence and compatibility are separate: a source can be verified
+while game compatibility still needs testing.
+
+## Edition manifest records
+
+Edition entries require an ID, name, category, edition, cross-edition status, manifest
+status, non-empty engine list, source/package fields, plugin/dependency/conflict/order lists,
+patch and testing notes, decision reason, and positive integer priority.
+
+- IDs use lowercase kebab-case.
+- `edition` is `openmw` or `mwse` and must match the containing edition.
+- Engine values must be supported by that edition.
+- Priorities are unique within each category.
+- `requires`, `conflicts`, `load_after`, and `load_before` reference IDs in the same manifest.
+- Planned records may retain blank or explicit placeholder source, URL, version, archive,
+  plugin, patch, and testing facts.
+- `testing` and `accepted` require positive, non-placeholder test evidence, a non-placeholder
+  `reviewed_by` list, and an ISO `last_reviewed` date in `YYYY-MM-DD` form. When linked, the
+  canonical candidate must use `source_confidence: verified`.
+- `accepted` also requires `source_reference`, a promoted canonical candidate whose
+  `promotion_target` includes the entry's edition, and compatible evidence for that edition.
+- `rejected`, `needs-patch`, and `deprecated` require non-placeholder decision rationale;
+  rejection additionally requires named human review and a review date.
+
+Edition manifest status values are `planned`, `testing`, `accepted`, `rejected`,
+`needs-patch`, and `deprecated`. They are independent of candidate status.
+
+## `source_reference`
+
+An edition entry may set optional `source_reference` to a canonical sourced-candidate ID.
+Validation checks that the source exists, names and intended editions agree, the candidate is
+not rejected or superseded, and `related_manifest_ids` links back.
+
+Planning and testing provenance links are independent of `promotion_target`. That field is
+enforced for acceptance, when a promoted candidate must target the accepting edition.
+
+The source record is canonical for source type, source URL, and source evidence. If a linked
+manifest repeats a non-placeholder source type or URL, it must agree with the canonical
+record. Linking does not:
+
+- change `candidate_status` or edition `status`;
+- prove compatibility or testing;
+- accept or promote the mod;
+- copy unknown versions, archives, plugins, or edition-specific behavior.
+
+See [`sourced-mod-workflow.md`](sourced-mod-workflow.md) for the lifecycle.
+
+## Generated Markdown
+
+`tools/generate_modlist_markdown.py` replaces only content between the
+`GENERATED-CONTENT` markers in each edition `MODLIST.md`. Use the normal command to refresh
+output and `--check` to compare without writing. Manual introductions remain outside the
+markers.

--- a/ash-archive/shared/naming-policy.md
+++ b/ash-archive/shared/naming-policy.md
@@ -1,3 +1,14 @@
 # Naming Policy
 
-Use lowercase kebab-case for IDs. Keep names exact to source where practical.
+- Use lowercase kebab-case for candidate and manifest IDs: `the-dream-is-the-door`.
+- Preserve the source's display name when it is known; do not normalize display names merely
+  to make the editions look identical.
+- Keep an ID stable after other records reference it. A rename must update every dependency,
+  conflict, load-order, `source_reference`, and `related_manifest_ids` link.
+- Use the same ID and display name across editions only for the same mod identity; edition
+  comparison fails when a shared-ID name drifts. Different engine-native implementations may
+  use different IDs with an explicit cross-edition rationale.
+- Use lowercase edition directory names `openmw` and `mwse`; public names remain Pilgrim and Sleeper.
+- Internal YAML control files use `.control.meta`. Do not confuse them with native MO2 `.meta` sidecars.
+
+Run manifest validation, duplicate scanning, and edition comparison after identifier changes.

--- a/ash-archive/shared/source-package-meta.control.meta
+++ b/ash-archive/shared/source-package-meta.control.meta
@@ -11,19 +11,19 @@ multi_package_sources:
         ".meta":
           variant_name: 6th House Robe Normal Mapped
           install_artifact: 6th House Robe Normal Mapped-52567-1-0-1681179314.7z
-          edition_notes: Texture-only package; expected to work in both OpenMW and MWSE.
+          edition_notes: Texture-only inventory record; engine compatibility has not been tested.
           plugin_list: []
       - id: sixth-house-glowing-things-normal-mapped
         ".meta":
           variant_name: 6th House - Glowing Things Normal Mapped
           install_artifact: 6th House - Glowing Things Normal Mapped-52567-1-0-1680228098.7z
-          edition_notes: Texture-only package; expected to work in both OpenMW and MWSE.
+          edition_notes: Texture-only inventory record; engine compatibility has not been tested.
           plugin_list: []
       - id: a-strange-plant-normal-mapped
         ".meta":
           variant_name: A Strange Plant Normal Mapped
           install_artifact: A Strange Plant Normal Mapped-52567-1-0-1682446048.7z
-          edition_notes: Texture-only package; expected to work in both OpenMW and MWSE.
+          edition_notes: Texture-only inventory record; engine compatibility has not been tested.
           plugin_list: []
       - id: aatl-data-normal-mapped
         ".meta":

--- a/ash-archive/shared/sourced-mod-workflow.md
+++ b/ash-archive/shared/sourced-mod-workflow.md
@@ -1,89 +1,91 @@
-# Sourced Mod Workflow (Candidate Intake Desk)
+# Sourced Mod Workflow
 
-`shared/sourced-mods.control.meta` is an **intake desk** for candidates, not a list of accepted mods. It is internal control metadata and **not** an MO2 download sidecar `.meta` file.
+`shared/sourced-mods.control.meta` is the canonical candidate intake and provenance layer.
+It is not an accepted-mod list and is not a native MO2 download sidecar.
 
+## 1. Candidate intake
 
-## Canonical metadata format (`.meta` extension, YAML-structured content)
+For each candidate, record a stable ID and name, primary source type and URL when known,
+source confidence, evidence notes, intended editions, thematic fit, compatibility status,
+risk, engine uncertainty, promotion target, and review fields. Leave unknown facts empty or
+explicitly unverified; never reconstruct a version, archive, plugin, or URL.
 
-In this repository, metadata files use the `.meta` extension (including `.control.meta` variants). Content remains YAML-structured.
+The file uses one top-level `sourced_candidates:` list. Do not replace it with bucket-grouped
+shapes.
 
-`shared/sourced-mods.control.meta` must use a **top-level `sourced_candidates:` list**.
+## 2. Candidate state machine
 
-```yaml
-sourced_candidates:
-  - id: example-mod-id
-    thematic_bucket: dream-sixth-house
-    # ...remaining required candidate fields
+Allowed candidate-review paths are:
+
+- `candidate` -> `under-review` -> `promoted`
+- `candidate` or `under-review` -> `rejected`
+- `candidate` or `under-review` -> `superseded`
+
+Human review is required for promotion, rejection, and supersession. Retain the evidence,
+rationale, a non-placeholder `reviewed_by` list, and an ISO `last_reviewed` date where validation
+requires a completed review.
+
+## 3. Provenance link to edition planning
+
+An existing or new edition planning entry may set `source_reference` to a sourced-candidate
+ID when identity and intended edition agree. Add the manifest ID to the source record's
+`related_manifest_ids` reverse link.
+
+This relationship can exist while the source remains `candidate` and the edition entry
+remains `planned`. It means only that canonical provenance is connected. It does not promote,
+accept, test, or prove compatibility, and it does not require unknown version/archive fields
+to be copied into the manifest.
+
+Canonical source records own source type, URL, and evidence. Edition manifests own engine
+behavior, plugins, requirements, conflicts, patches, test results, and load-order relations.
+
+## 4. Edition state machine
+
+Edition status is independent of candidate status:
+
+- `planned` records intent and may retain honest placeholders.
+- `testing` requires recorded package/version and positive test evidence, a non-placeholder
+  `reviewed_by` list, and `last_reviewed` in `YYYY-MM-DD` form. A linked canonical candidate
+  must have `source_confidence: verified`.
+- `accepted` requires `source_reference`, human review, a promoted canonical candidate,
+  whose `promotion_target` includes the edition, compatible evidence for that edition, and
+  complete edition-specific review notes.
+- `needs-patch`, `rejected`, and `deprecated` describe edition decisions and must retain
+  non-placeholder rationale. Rejection also requires named human review and a review date.
+
+Changing one state machine never changes the other implicitly.
+
+## 5. Evaluation and promotion
+
+Use [`mod-evaluation-rubric.md`](mod-evaluation-rubric.md) and edition-specific test routes.
+Record what was tested, configuration, result, reviewer, and unresolved risk separately for
+Pilgrim and Sleeper. Upstream tags may inform planning but are not in-game evidence.
+
+Promotion into one edition does not require parity in the other. Preserve engine-native
+implementations and explain intentional differences.
+
+## 6. Unknown-origin and package gates
+
+`source-triage.control.meta` tracks unresolved imported inventory entries. While its gate is
+open, affected records remain unverified until identity, source, package, and licensing
+questions are resolved.
+
+Use `source-package-meta.control.meta` when one source page distributes multiple packages.
+Keep shared parent provenance separate from child variant, artifact, plugin, edition, and
+version evidence. A local imported path is snapshot evidence, not a portable acquisition instruction.
+
+## 7. Validation and generation
+
+From `ash-archive/`, run:
+
+```bash
+python tools/validate_manifests.py
+python tools/check_duplicate_mods.py
+python tools/compare_editions.py
+python tools/generate_modlist_markdown.py
+python tools/generate_modlist_markdown.py --check
+pytest
 ```
 
-Do not use bucket-grouped shapes like `buckets: -> candidates:` in this file.
-
-## Candidate intake
-
-For each sourced candidate:
-
-1. Record the source candidate with a stable kebab-case `id` and `name`.
-2. Capture `evidence_notes` and `source_url` (or leave URL empty when unknown).
-3. Set `source_confidence` (`verified`, `likely`, or `unverified`).
-4. Set `compatibility_status` conservatively:
-   - keep `unverified` until tested or backed by reliable documentation
-   - use `needs-testing` or `conflicting-reports` when appropriate
-5. Assign one `thematic_bucket` matching project pillars.
-6. Assign `promotion_target` (`openmw`, `mwse`, `both`, `neither`, or `undecided`).
-7. Document `risk_level` and relevant engine-specific uncertainty in `engine_notes`.
-
-## Promotion paths
-
-Allowed status transitions:
-
-- `candidate` → `under-review` → `promoted`
-- `candidate` → `rejected`
-- `candidate` → `superseded`
-
-## Promotion into edition manifests
-
-- `promoted` candidates should only be added to edition manifests after human review.
-- Promotion can differ between OpenMW and MWSE.
-- Preserve edition-specific implementation logic during promotion.
-- Do not force feature parity between editions.
-
-## Rejection and evidence retention
-
-- Keep rejected entries with reasoning in `promotion_notes`/`evidence_notes`.
-- Do not delete rejection evidence lightly; historical context is valuable for future triage.
-
-## Testing and compatibility claims
-
-- Compatibility remains `unverified` until tested or backed by reliable documentation.
-- If compatibility is marked as tested-compatible (`openmw-compatible`, `mwse-compatible`, or `both-compatible`), include notes describing what was tested and how.
-
-## Source triage gate for unmanaged/unknown-origin entries
-
-- `shared/source-triage.control.meta` tracks active `modlist.txt` entries with `Nexus_ID` of `0` or `-1`.
-- While `source_triage.triage_status` is `open`, listed entries are blocked from `.control.meta` promotion.
-- Keep listed entries in an `unverified` state until triage is closed and package identity + license/source questions are resolved.
-- Only after triage closure may entries move to normal `planned`/`candidate`/`rejected` flows for manifest promotion.
-
-## Multi-package control metadata convention
-
-Use `shared/source-package-meta.control.meta` when a single source page (for example one Nexus ID) distributes multiple installable packages.
-
-- Parent-level control records shared source metadata once:
-  - `nexus_id`
-  - `nexus_url`
-  - `base_version`
-  - `provenance`
-- Child/package-level control records package-specific metadata:
-  - `variant_name`
-  - `install_artifact`
-  - `edition_notes`
-  - `plugin_list`
-  - optional `package_version` when it differs from `base_version`
-
-### Version override rules
-
-1. Treat parent control `base_version` as the default version for all packages under that source.
-2. If a package has a different version than the parent, set child `package_version` explicitly.
-3. When both are present, child `package_version` is authoritative for that package.
-4. Do not mutate parent `base_version` to match a one-off child package; keep parent version as the shared default for the source page.
-5. If many packages diverge and no stable default exists, set parent `base_version` to the most current shared baseline and keep explicit child overrides for all divergences.
+Review generated diffs. The public modlists are planning views and do not replace source or
+manifest evidence.

--- a/ash-archive/shared/sourced-mods.control.meta
+++ b/ash-archive/shared/sourced-mods.control.meta
@@ -13,7 +13,8 @@ sourced_candidates:
     candidate_status: candidate
     reviewed_by: []
     last_reviewed: ""
-    related_manifest_ids: []
+    related_manifest_ids:
+      - the-dream-is-the-door
     evidence_notes: Nexus page describes the Cavern of the Incarnate entrance becoming visible only at twilight.
     engine_notes: Nexus page lists both OpenMW and MWSE tags.
     promotion_notes: Verify quest progression behavior around Cavern of the Incarnate timing in both OpenMW and MWSE, and confirm no blockers for main-quest access.
@@ -32,7 +33,8 @@ sourced_candidates:
     candidate_status: candidate
     reviewed_by: []
     last_reviewed: ""
-    related_manifest_ids: []
+    related_manifest_ids:
+      - lucid-disturbing-dreams
     evidence_notes: Nexus page states the four disturbing dream textboxes are replaced with voiced playable dream sequences.
     engine_notes: Nexus page includes OpenMW and MWSE tags.
     promotion_notes: Test each main-quest dream trigger, subtitle/audio behavior, and ensure no quest-state softlocks in either edition.
@@ -51,7 +53,8 @@ sourced_candidates:
     candidate_status: candidate
     reviewed_by: []
     last_reviewed: ""
-    related_manifest_ids: []
+    related_manifest_ids:
+      - beware-the-sixth-house
     evidence_notes: Nexus page presents this as an overhaul that makes Sixth House enemies more dangerous.
     engine_notes: Nexus page has no explicit hard engine requirement beyond Morrowind.
     promotion_notes: Run balance passes in early/mid/late Sixth House encounters for both editions and check for pacing spikes or unavoidable difficulty walls.
@@ -70,7 +73,8 @@ sourced_candidates:
     candidate_status: candidate
     reviewed_by: []
     last_reviewed: ""
-    related_manifest_ids: []
+    related_manifest_ids:
+      - kogoruhn-extinct-city-of-ash-and-sulfur
     evidence_notes: Nexus page describes a major Kogoruhn location overhaul themed around ash and sulfur.
     engine_notes: Nexus page does not clearly state OpenMW/MWSE-only requirements.
     promotion_notes: Validate compatibility with quest routing, pathing, and major dungeon/location edits in both editions before promotion.
@@ -89,7 +93,8 @@ sourced_candidates:
     candidate_status: candidate
     reviewed_by: []
     last_reviewed: ""
-    related_manifest_ids: []
+    related_manifest_ids:
+      - creeping-blight
     evidence_notes: Nexus page describes blight weather expansion linked to main quest progress, with MWSE time-based expansion support.
     engine_notes: Nexus page indicates support for OpenMW and MWSE behavior paths.
     promotion_notes: Confirm weather progression logic and regional intensity in both editions, including MWSE elapsed-time behavior where applicable.
@@ -108,7 +113,8 @@ sourced_candidates:
     candidate_status: candidate
     reviewed_by: []
     last_reviewed: ""
-    related_manifest_ids: []
+    related_manifest_ids:
+      - it-beats-openmw
     evidence_notes: Nexus page describes Red Mountain heartbeat ambience implementation for OpenMW.
     engine_notes: Nexus page clearly identifies OpenMW-only target.
     promotion_notes: Validate ambient trigger zones, volume balance, and interaction with weather/audio mods in OpenMW.
@@ -127,7 +133,8 @@ sourced_candidates:
     candidate_status: candidate
     reviewed_by: []
     last_reviewed: ""
-    related_manifest_ids: []
+    related_manifest_ids:
+      - heartthrum
     evidence_notes: Nexus page describes Red Mountain heartbeat ambience for MWSE/MGE XE setups.
     engine_notes: Nexus page indicates MWSE and MGE XE requirements.
     promotion_notes: Verify heartbeat ambience triggers and performance with MWSE-heavy stacks and regional weather/audio combinations.
@@ -146,7 +153,8 @@ sourced_candidates:
     candidate_status: candidate
     reviewed_by: []
     last_reviewed: ""
-    related_manifest_ids: []
+    related_manifest_ids:
+      - ashfall
     evidence_notes: Nexus page describes survival mechanics including needs and camping systems.
     engine_notes: Nexus page specifies MWSE dependency.
     promotion_notes: Stress-test survival loop settings, UI flow, and compatibility with travel/economy mods in MWSE before any promotion.

--- a/ash-archive/shared/test-routes.md
+++ b/ash-archive/shared/test-routes.md
@@ -1,3 +1,27 @@
 # Test Routes
 
-Define repeatable play routes for early game, faction progression, and Red Mountain thresholds.
+No repeatable in-game route has been completed and recorded yet. This page defines the
+minimum evidence format; it is not a claim that either edition has passed testing.
+
+## Route record
+
+For every run, record:
+
+- edition, build/commit, game and engine versions, and enabled package set;
+- clean or migrated save state and relevant configuration;
+- route name, start/end state, checkpoints, expected observations, and actual result;
+- crashes, warnings, quest-state changes, visual/audio defects, performance observations,
+  conflicts, and reproduction steps;
+- tester and date.
+
+## Planned route families
+
+- Early-game traversal and core service access.
+- Main-quest dream and Sixth House progression.
+- Faction and Temple/faith progression.
+- Tomb, canton, foyada, and ash-weather atmosphere passes.
+- Dagoth Gares/Corprus and Lost Prophecies thresholds.
+- Kogoruhn, Cavern of the Incarnate, Red Mountain, and Heart endgame thresholds.
+
+Pilgrim and Sleeper results remain independent. A route passing in one engine is not evidence
+for the other, and repository validation is not a substitute for running a route.

--- a/ash-archive/tests/test_compare_editions.py
+++ b/ash-archive/tests/test_compare_editions.py
@@ -1,3 +1,4 @@
+from tools.compare_editions import find_cross_name_mismatches, find_cross_status_mismatches
 from tools.lib.manifest import load_mods
 from tools.lib.paths import manifest_path
 
@@ -13,3 +14,17 @@ def test_each_edition_has_unique_ids() -> None:
     mwse = {m["id"] for m in load_mods(manifest_path("mwse"))}
     assert openmw - mwse
     assert mwse - openmw
+
+
+def test_cross_edition_status_mismatch_is_detected() -> None:
+    openmw = {"shared-id": {"cross_edition_status": "equivalent-needed"}}
+    mwse = {"shared-id": {"cross_edition_status": "different-implementation"}}
+
+    assert find_cross_status_mismatches(openmw, mwse) == ["shared-id"]
+
+
+def test_cross_edition_name_mismatch_is_detected() -> None:
+    openmw = {"shared-id": {"name": "Shared Identity"}}
+    mwse = {"shared-id": {"name": "Different Identity"}}
+
+    assert find_cross_name_mismatches(openmw, mwse) == ["shared-id"]

--- a/ash-archive/tests/test_duplicate_mods.py
+++ b/ash-archive/tests/test_duplicate_mods.py
@@ -1,5 +1,8 @@
+from pathlib import Path
+
 from tools.check_duplicate_mods import (
     DuplicateReport,
+    _load_mods_for_path,
     find_cross_edition_name_mismatches,
     find_duplicates,
 )
@@ -33,3 +36,10 @@ def test_cross_edition_duplicate_names_with_different_ids_warn() -> None:
             "mwse: patch-for-purists-mwse; openmw: patch-for-purists-openmw",
         )
     ]
+
+
+def test_load_failure_is_reported_to_caller(tmp_path: Path) -> None:
+    mods, load_failed = _load_mods_for_path(tmp_path / "missing.control.meta")
+
+    assert mods == []
+    assert load_failed is True

--- a/ash-archive/tests/test_generation.py
+++ b/ash-archive/tests/test_generation.py
@@ -1,0 +1,38 @@
+from pathlib import Path
+
+import pytest
+
+from tools.generate_modlist_markdown import END, START, expected_modlist, render_modlist_document
+
+
+def test_render_modlist_document_is_idempotent() -> None:
+    initial = f"# Modlist\n\nIntro.\n\n{START}\nold\n{END}\n"
+    generated = render_modlist_document(initial, "new\n")
+
+    assert render_modlist_document(generated, "new\n") == generated
+    assert generated == f"# Modlist\n\nIntro.\n\n{START}\nnew\n{END}\n"
+
+
+@pytest.mark.parametrize(
+    "document",
+    [
+        f"# Modlist\n{START}\nmissing end\n",
+        f"# Modlist\n{END}\nmissing start\n",
+        f"# Modlist\n{START}\none\n{END}\n{START}\ntwo\n{END}\n",
+        f"# Modlist\n{END}\n{START}\n",
+    ],
+)
+def test_render_modlist_document_rejects_invalid_markers(document: str) -> None:
+    with pytest.raises(ValueError):
+        render_modlist_document(document, "generated\n")
+
+
+def test_expected_modlist_does_not_write(tmp_path: Path) -> None:
+    path = tmp_path / "MODLIST.md"
+    path.write_text("# Modlist\n", encoding="utf-8")
+
+    current, expected = expected_modlist(path, "generated\n")
+
+    assert current == "# Modlist\n"
+    assert expected != current
+    assert path.read_text(encoding="utf-8") == current

--- a/ash-archive/tests/test_lint_repo.py
+++ b/ash-archive/tests/test_lint_repo.py
@@ -1,0 +1,53 @@
+from pathlib import Path
+
+from tools.lint_repo import _conflict_marker_issues, _is_ignored_repo_path, _markdown_link_issues
+
+
+def test_repo_scan_ignores_generated_and_test_artifact_directories() -> None:
+    assert _is_ignored_repo_path(Path(".codex-pytest-run") / "fixture.md")
+    assert _is_ignored_repo_path(Path("package.egg-info") / "README.md")
+    assert _is_ignored_repo_path(Path("build") / "README.md")
+    assert _is_ignored_repo_path(Path(".venv") / "README.md")
+    assert not _is_ignored_repo_path(Path(".agents") / "skills" / "SKILL.md")
+
+
+def test_conflict_marker_check_covers_plain_text_inventory(tmp_path: Path) -> None:
+    inventory = tmp_path / "modlist.txt"
+    inventory.write_text("<<<<<<< local\nentry\n=======\nother\n>>>>>>> remote\n", encoding="utf-8")
+
+    issues = _conflict_marker_issues(inventory, tmp_path)
+
+    assert issues == [
+        "modlist.txt:1: unresolved merge marker",
+        "modlist.txt:3: unresolved merge marker",
+        "modlist.txt:5: unresolved merge marker",
+    ]
+
+
+def test_markdown_link_check_accepts_existing_relative_target(tmp_path: Path) -> None:
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    target = tmp_path / "target.md"
+    target.write_text("# Target\n", encoding="utf-8")
+    source = docs / "source.md"
+    source.write_text("[Target](../target.md#section)\n", encoding="utf-8")
+
+    assert _markdown_link_issues(source, tmp_path) == []
+
+
+def test_markdown_link_check_reports_missing_target(tmp_path: Path) -> None:
+    source = tmp_path / "source.md"
+    source.write_text("[Missing](missing.md)\n", encoding="utf-8")
+
+    assert _markdown_link_issues(source, tmp_path) == [
+        "source.md:1: broken internal link 'missing.md'"
+    ]
+
+
+def test_markdown_link_check_ignores_external_and_page_anchor_links(tmp_path: Path) -> None:
+    source = tmp_path / "source.md"
+    source.write_text(
+        "[External](https://example.invalid/path) [Section](#section)\n", encoding="utf-8"
+    )
+
+    assert _markdown_link_issues(source, tmp_path) == []

--- a/ash-archive/tests/test_repo_agents.py
+++ b/ash-archive/tests/test_repo_agents.py
@@ -7,6 +7,62 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 PRESET_DIR = REPO_ROOT / ".agents" / "presets"
 AGENT_DIR = REPO_ROOT / ".codex" / "agents"
 
+EXPECTED_PRESETS = {
+    "documentation-sync-agent",
+    "edition-drift-auditor",
+    "manifest-lint-agent",
+    "modlist-regenerator",
+    "release-readiness-agent",
+    "source-triage-agent",
+    "wabbajack-list-planner",
+    "wabbajack-list-writer",
+}
+REQUIRED_PRESET_FIELDS = {
+    "name",
+    "purpose",
+    "mode",
+    "scope",
+    "read_before_editing",
+    "allowed_actions",
+    "forbidden_actions",
+    "required_checks",
+    "stop_conditions",
+    "handoff",
+    "human_review_required_for",
+}
+OPTIONAL_PRESET_FIELDS = {"preference_source", "taste_lenses", "voice_rules"}
+LIST_FIELDS = {
+    "scope",
+    "read_before_editing",
+    "allowed_actions",
+    "forbidden_actions",
+    "stop_conditions",
+    "human_review_required_for",
+}
+BASELINE_READS = {
+    "AGENT-RULES.md",
+    "ash-archive/LOCAL-AGENT-PRESETS.md",
+    "ash-archive/PROJECT-BIBLE.md",
+}
+BASELINE_FORBIDDEN_ACTIONS = {
+    "invent_mod_metadata",
+    "accept_or_reject_mods_without_human_review",
+    "claim_compatibility_without_evidence",
+}
+BASELINE_HUMAN_GATES = {
+    "accepting_or_rejecting_mods",
+    "promoting_candidates_into_edition_manifests",
+    "compatibility_claims_based_on_playtesting",
+}
+CANONICAL_BINDINGS = {
+    "scope",
+    "allowed_actions",
+    "forbidden_actions",
+    "required_checks",
+    "stop_conditions",
+    "human_review_required_for",
+}
+
 
 def _yaml_presets() -> dict[str, dict]:
     return {
@@ -22,34 +78,77 @@ def _toml_agents() -> dict[str, dict]:
     }
 
 
+def test_canonical_preset_contracts_are_complete_and_conservative() -> None:
+    presets = _yaml_presets()
+    assert presets.keys() == EXPECTED_PRESETS
+
+    for stem, preset in presets.items():
+        assert isinstance(preset, dict)
+        assert REQUIRED_PRESET_FIELDS <= set(preset)
+        assert set(preset) <= REQUIRED_PRESET_FIELDS | OPTIONAL_PRESET_FIELDS
+        assert preset["name"] == stem
+        assert isinstance(preset["purpose"], str) and preset["purpose"].strip()
+        assert isinstance(preset["mode"], str) and preset["mode"].strip()
+
+        for field in LIST_FIELDS:
+            values = preset[field]
+            assert isinstance(values, list) and values, f"{stem} has no {field}"
+            assert all(isinstance(value, str) and value.strip() for value in values)
+            assert len(values) == len(set(values)), f"{stem} has duplicate {field} entries"
+
+        assert BASELINE_READS <= set(preset["read_before_editing"])
+        assert BASELINE_FORBIDDEN_ACTIONS <= set(preset["forbidden_actions"])
+        assert BASELINE_HUMAN_GATES <= set(preset["human_review_required_for"])
+
+        checks = preset["required_checks"]
+        assert isinstance(checks, list) and checks
+        for check in checks:
+            assert isinstance(check, dict)
+            assert {"working_directory", "command"} <= check.keys()
+            assert check.keys() <= {"working_directory", "command", "when"}
+            assert check["working_directory"] == "ash-archive"
+            assert isinstance(check["command"], str) and check["command"].strip()
+
+        handoff = preset["handoff"]
+        assert isinstance(handoff, dict) and handoff
+        assert all(isinstance(key, str) and value is True for key, value in handoff.items())
+
+
 def test_repo_agent_set_matches_canonical_presets() -> None:
-    assert _toml_agents().keys() == _yaml_presets().keys()
+    assert _toml_agents().keys() == _yaml_presets().keys() == EXPECTED_PRESETS
 
 
-def test_repo_agents_include_required_codex_fields_and_preset_guardrails() -> None:
+def test_repo_agents_preserve_the_complete_canonical_safety_contract() -> None:
     presets = _yaml_presets()
 
     for stem, agent in _toml_agents().items():
+        assert set(agent) == {"name", "description", "developer_instructions"}
         assert agent["name"] == stem
         assert agent["description"].strip()
         instructions = agent["developer_instructions"]
         assert instructions.strip()
 
         preset = presets[stem]
-        for required_path in preset.get("read_before_editing", []):
+        canonical_reference = f".agents/presets/{stem}.yaml"
+        assert canonical_reference in instructions
+        assert "completely before acting" in instructions
+        for binding in CANONICAL_BINDINGS:
+            assert f"`{binding}`" in instructions, f"{stem} does not bind {binding}"
+        for required_path in preset["read_before_editing"]:
             assert required_path in instructions, f"{stem} does not require reading {required_path}"
-        for forbidden_action in preset.get("forbidden_actions", []):
-            assert forbidden_action in instructions, (
-                f"{stem} does not preserve forbidden action {forbidden_action}"
-            )
-        for check in preset.get("required_checks", []):
+        for check in preset["required_checks"]:
             assert check["command"] in instructions, (
                 f"{stem} does not preserve required check {check['command']}"
             )
+        for field in ("forbidden_actions", "stop_conditions", "human_review_required_for"):
+            for identifier in preset[field]:
+                assert identifier in instructions, f"{stem} does not preserve {field}: {identifier}"
 
 
 def test_root_agents_file_loads_repository_policy() -> None:
     guidance = (REPO_ROOT / "AGENTS.md").read_text(encoding="utf-8")
     assert "AGENT-RULES.md" in guidance
     assert "ash-archive/PROJECT-BIBLE.md" in guidance
+    assert ".agents/presets/" in guidance
     assert ".codex/agents/" in guidance
+    assert ".agents/skills/" in guidance

--- a/ash-archive/tests/test_repo_skills.py
+++ b/ash-archive/tests/test_repo_skills.py
@@ -1,5 +1,12 @@
-from tools.lint_repo import SKILL_PRESETS, validate_repo_configuration
+from pathlib import Path
 
+import yaml
+
+from tools.lint_repo import SKILL_PRESETS, _load_skill, validate_repo_configuration
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SKILL_ROOT = REPO_ROOT / ".agents" / "skills"
+PRESET_ROOT = REPO_ROOT / ".agents" / "presets"
 EXPECTED_SKILL_PRESETS = {
     "ash-archive-triage-sources": "source-triage-agent.yaml",
     "ash-archive-lint-manifests": "manifest-lint-agent.yaml",
@@ -10,8 +17,58 @@ EXPECTED_SKILL_PRESETS = {
     "ash-archive-plan-wabbajack-list": "wabbajack-list-planner.yaml",
     "ash-archive-write-wabbajack-copy": "wabbajack-list-writer.yaml",
 }
+CANONICAL_BINDINGS = {
+    "scope",
+    "allowed_actions",
+    "forbidden_actions",
+    "required_checks",
+    "stop_conditions",
+    "human_review_required_for",
+}
 
 
-def test_repo_skill_workflows_are_complete() -> None:
+def test_repo_skill_set_has_one_exact_canonical_preset_mapping() -> None:
+    skill_names = {path.parent.name for path in SKILL_ROOT.glob("*/SKILL.md")}
     assert SKILL_PRESETS == EXPECTED_SKILL_PRESETS
+    assert skill_names == EXPECTED_SKILL_PRESETS.keys()
+
+
+def test_repo_skills_preserve_reading_checks_and_canonical_guardrails() -> None:
+    for skill_name, preset_filename in EXPECTED_SKILL_PRESETS.items():
+        skill_path = SKILL_ROOT / skill_name / "SKILL.md"
+        metadata, body = _load_skill(skill_path)
+        preset = yaml.safe_load((PRESET_ROOT / preset_filename).read_text(encoding="utf-8"))
+
+        assert metadata["name"] == skill_name
+        assert metadata["description"].strip()
+        canonical_reference = f".agents/presets/{preset_filename}"
+        assert canonical_reference in body
+        assert "completely before acting" in body
+        for binding in CANONICAL_BINDINGS:
+            assert f"`{binding}`" in body, f"{skill_name} does not bind {binding}"
+        for required_path in preset["read_before_editing"]:
+            assert required_path in body, f"{skill_name} does not require reading {required_path}"
+        for check in preset["required_checks"]:
+            assert check["command"] in body, (
+                f"{skill_name} does not preserve required check {check['command']}"
+            )
+
+        normalized_body = " ".join(body.split())
+        assert "Never invent mod metadata" in normalized_body
+        assert "accept or reject a mod" in normalized_body
+        assert "promote a candidate" in normalized_body
+        assert "claim compatibility without documented evidence and human review" in normalized_body
+
+        interface_path = skill_path.parent / "agents" / "openai.yaml"
+        interface_data = yaml.safe_load(interface_path.read_text(encoding="utf-8"))
+        assert set(interface_data) == {"interface"}
+        assert set(interface_data["interface"]) == {
+            "display_name",
+            "short_description",
+            "default_prompt",
+        }
+        assert f"${skill_name}" in interface_data["interface"]["default_prompt"]
+
+
+def test_repo_configuration_lint_covers_skill_workflows() -> None:
     assert validate_repo_configuration() == []

--- a/ash-archive/tests/test_sourced_mods.py
+++ b/ash-archive/tests/test_sourced_mods.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import subprocess
 from pathlib import Path
 
+import pytest
 import yaml
 
 from tools.lib.sourced_mods import validate_sourced_mods
@@ -73,6 +74,17 @@ def test_invalid_thematic_bucket_fails(tmp_path: Path) -> None:
     assert any("invalid thematic_bucket" in error for error in errors)
 
 
+def test_blank_candidate_name_fails(tmp_path: Path) -> None:
+    candidate = dict(FIXTURE_REQUIRED_FIELDS)
+    candidate["name"] = "  "
+    fixture = tmp_path / "sourced-mods.control.meta"
+    _write_sourced(fixture, [candidate])
+
+    _, errors = validate_sourced_mods(fixture)
+
+    assert any("field 'name' must not be blank" in error for error in errors)
+
+
 def test_invalid_intended_editions_fails(tmp_path: Path) -> None:
     candidate = dict(FIXTURE_REQUIRED_FIELDS)
     candidate["intended_editions"] = ["both"]
@@ -121,3 +133,168 @@ def test_summary_tool_returns_nonzero_for_invalid_fixture() -> None:
 
     assert result.returncode != 0
     assert "[ERROR]" in result.stdout
+
+
+def test_duplicate_candidate_ids_fail(tmp_path: Path) -> None:
+    first = dict(FIXTURE_REQUIRED_FIELDS)
+    second = dict(FIXTURE_REQUIRED_FIELDS)
+    fixture = tmp_path / "sourced-mods.control.meta"
+    _write_sourced(fixture, [first, second])
+
+    _, errors = validate_sourced_mods(fixture)
+
+    assert any("duplicate id in sourced candidates" in error for error in errors)
+
+
+@pytest.mark.parametrize(
+    "url",
+    ["nexusmods.com/morrowind/mods/1", "ftp://example.com/mod", "https://exa mple.com"],
+)
+def test_malformed_source_url_fails(tmp_path: Path, url: str) -> None:
+    candidate = dict(FIXTURE_REQUIRED_FIELDS)
+    candidate["source_url"] = url
+    fixture = tmp_path / "sourced-mods.control.meta"
+    _write_sourced(fixture, [candidate])
+
+    _, errors = validate_sourced_mods(fixture)
+
+    assert any("malformed source_url" in error for error in errors)
+
+
+def test_verified_source_requires_canonical_evidence_but_not_human_review(tmp_path: Path) -> None:
+    candidate = dict(FIXTURE_REQUIRED_FIELDS)
+    candidate.update(
+        {
+            "source_type": "nexus",
+            "source_url": "https://www.nexusmods.com/morrowind/mods/1",
+            "source_confidence": "verified",
+            "evidence_notes": "The source page identifies the candidate.",
+        }
+    )
+    fixture = tmp_path / "sourced-mods.control.meta"
+    _write_sourced(fixture, [candidate])
+
+    _, errors = validate_sourced_mods(fixture)
+
+    assert errors == []
+
+
+@pytest.mark.parametrize(
+    ("overrides", "expected"),
+    [
+        ({"source_url": ""}, "requires a valid source_url"),
+        ({"source_type": "unknown"}, "cannot use source_type 'unknown'"),
+        ({"evidence_notes": "needs verification"}, "requires evidence_notes"),
+    ],
+)
+def test_verified_source_rejects_placeholder_states(
+    tmp_path: Path, overrides: dict, expected: str
+) -> None:
+    candidate = dict(FIXTURE_REQUIRED_FIELDS)
+    candidate.update(
+        {
+            "source_type": "nexus",
+            "source_url": "https://www.nexusmods.com/morrowind/mods/1",
+            "source_confidence": "verified",
+            "evidence_notes": "The source page identifies the candidate.",
+        }
+    )
+    candidate.update(overrides)
+    fixture = tmp_path / "sourced-mods.control.meta"
+    _write_sourced(fixture, [candidate])
+
+    _, errors = validate_sourced_mods(fixture)
+
+    assert any(expected in error for error in errors)
+
+
+def test_compatibility_claim_requires_evidence_and_review(tmp_path: Path) -> None:
+    candidate = dict(FIXTURE_REQUIRED_FIELDS)
+    candidate.update(
+        {
+            "compatibility_status": "openmw-compatible",
+            "engine_notes": "needs verification",
+            "evidence_notes": "needs verification",
+        }
+    )
+    fixture = tmp_path / "sourced-mods.control.meta"
+    _write_sourced(fixture, [candidate])
+
+    _, errors = validate_sourced_mods(fixture)
+
+    joined = "\n".join(errors)
+    assert "requires evidence and engine notes" in joined
+    assert "requires review information" in joined
+
+
+def test_compatibility_claim_rejects_placeholder_reviewer(tmp_path: Path) -> None:
+    candidate = dict(FIXTURE_REQUIRED_FIELDS)
+    candidate.update(
+        {
+            "compatibility_status": "openmw-compatible",
+            "engine_notes": "OpenMW test route passed.",
+            "evidence_notes": "Recorded test evidence supports OpenMW.",
+            "reviewed_by": ["TBD"],
+            "last_reviewed": "2026-07-17",
+        }
+    )
+    fixture = tmp_path / "sourced-mods.control.meta"
+    _write_sourced(fixture, [candidate])
+
+    _, errors = validate_sourced_mods(fixture)
+
+    joined = "\n".join(errors)
+    assert "reviewed_by' must be non-placeholder" in joined
+    assert "requires review information" in joined
+
+
+def test_promoted_candidate_requires_review_notes_and_manifest_link(tmp_path: Path) -> None:
+    candidate = dict(FIXTURE_REQUIRED_FIELDS)
+    candidate.update({"candidate_status": "promoted", "promotion_target": "openmw"})
+    fixture = tmp_path / "sourced-mods.control.meta"
+    _write_sourced(fixture, [candidate])
+
+    _, errors = validate_sourced_mods(fixture)
+
+    joined = "\n".join(errors)
+    assert "requires related_manifest_ids" in joined
+    assert "requires promotion_notes" in joined
+    assert "requires review information" in joined
+
+
+@pytest.mark.parametrize("candidate_status", ["rejected", "superseded"])
+def test_terminal_candidate_decision_requires_notes_and_review(
+    tmp_path: Path, candidate_status: str
+) -> None:
+    candidate = dict(FIXTURE_REQUIRED_FIELDS)
+    candidate["candidate_status"] = candidate_status
+    fixture = tmp_path / "sourced-mods.control.meta"
+    _write_sourced(fixture, [candidate])
+
+    _, errors = validate_sourced_mods(fixture)
+
+    joined = "\n".join(errors)
+    assert "requires promotion_notes" in joined
+    assert "requires review information" in joined
+
+
+def test_malformed_related_manifest_reference_fails(tmp_path: Path) -> None:
+    candidate = dict(FIXTURE_REQUIRED_FIELDS)
+    candidate["related_manifest_ids"] = ["Bad Manifest ID"]
+    fixture = tmp_path / "sourced-mods.control.meta"
+    _write_sourced(fixture, [candidate])
+
+    _, errors = validate_sourced_mods(fixture)
+
+    assert any("malformed reference" in error for error in errors)
+
+
+def test_promotion_target_must_fit_intended_editions(tmp_path: Path) -> None:
+    candidate = dict(FIXTURE_REQUIRED_FIELDS)
+    candidate["promotion_target"] = "mwse"
+    fixture = tmp_path / "sourced-mods.control.meta"
+    _write_sourced(fixture, [candidate])
+
+    _, errors = validate_sourced_mods(fixture)
+
+    assert any("promotion_target 'mwse' contradicts intended_editions" in error for error in errors)

--- a/ash-archive/tests/test_validation.py
+++ b/ash-archive/tests/test_validation.py
@@ -3,7 +3,8 @@ from pathlib import Path
 import pytest
 import yaml
 
-from tools.lib.validation import validate_manifest
+from tools import validate_manifests as manifest_validator
+from tools.lib.validation import validate_manifest, validate_source_references
 
 FIXTURE_REQUIRED_FIELDS = {
     "id": "sample-mod",
@@ -81,6 +82,17 @@ def test_invalid_category_fails(tmp_path: Path) -> None:
     assert any("invalid category" in error for error in errors)
 
 
+def test_blank_manifest_name_fails(tmp_path: Path) -> None:
+    mod = dict(FIXTURE_REQUIRED_FIELDS)
+    mod["name"] = "  "
+    fixture = tmp_path / "mods.control.meta"
+    _write_manifest(fixture, [mod])
+
+    errors = validate_manifest(fixture, "openmw")
+
+    assert any("field 'name' must not be blank" in error for error in errors)
+
+
 @pytest.mark.parametrize(
     "invalid_id",
     ["Patch For Purists", "patch_for_purists", "Patch-for-Purists", "patch for purists"],
@@ -107,6 +119,25 @@ def test_edition_mismatch_fails(tmp_path: Path) -> None:
     assert any("edition mismatch" in error for error in errors)
 
 
+@pytest.mark.parametrize(
+    ("edition", "cross_edition_status"),
+    [("openmw", "mwse-only"), ("mwse", "openmw-only")],
+)
+def test_cross_edition_status_must_match_manifest_edition(
+    tmp_path: Path, edition: str, cross_edition_status: str
+) -> None:
+    mod = dict(FIXTURE_REQUIRED_FIELDS)
+    mod["edition"] = edition
+    mod["engine"] = [edition]
+    mod["cross_edition_status"] = cross_edition_status
+    fixture = tmp_path / "mods.control.meta"
+    _write_manifest(fixture, [mod])
+
+    errors = validate_manifest(fixture, edition)
+
+    assert any("incompatible with edition" in error for error in errors)
+
+
 def test_openmw_manifest_rejects_mwse_engine_value(tmp_path: Path) -> None:
     mod = dict(FIXTURE_REQUIRED_FIELDS)
     mod["engine"] = ["mwse"]
@@ -127,3 +158,423 @@ def test_engine_unknown_cannot_be_combined(tmp_path: Path) -> None:
     errors = validate_manifest(fixture, "openmw")
 
     assert any("cannot combine 'unknown'" in error for error in errors)
+
+
+def test_duplicate_ids_fail(tmp_path: Path) -> None:
+    first = dict(FIXTURE_REQUIRED_FIELDS)
+    second = dict(FIXTURE_REQUIRED_FIELDS)
+    second["priority"] = 2
+    fixture = tmp_path / "mods.control.meta"
+    _write_manifest(fixture, [first, second])
+
+    errors = validate_manifest(fixture, "openmw")
+
+    assert any("duplicate id in manifest" in error for error in errors)
+
+
+def test_duplicate_priority_within_category_fails(tmp_path: Path) -> None:
+    first = dict(FIXTURE_REQUIRED_FIELDS)
+    second = dict(FIXTURE_REQUIRED_FIELDS, id="second-mod", name="Second Mod")
+    fixture = tmp_path / "mods.control.meta"
+    _write_manifest(fixture, [first, second])
+
+    errors = validate_manifest(fixture, "openmw")
+
+    assert any("duplicate priority 1 within category" in error for error in errors)
+
+
+def test_same_priority_in_different_categories_passes(tmp_path: Path) -> None:
+    first = dict(FIXTURE_REQUIRED_FIELDS)
+    second = dict(
+        FIXTURE_REQUIRED_FIELDS,
+        id="second-mod",
+        name="Second Mod",
+        category="Engine and Foundation",
+    )
+    fixture = tmp_path / "mods.control.meta"
+    _write_manifest(fixture, [first, second])
+
+    errors = validate_manifest(fixture, "openmw")
+
+    assert errors == []
+
+
+@pytest.mark.parametrize("priority", [0, -1, True])
+def test_priority_must_be_positive_integer(tmp_path: Path, priority: object) -> None:
+    mod = dict(FIXTURE_REQUIRED_FIELDS)
+    mod["priority"] = priority
+    fixture = tmp_path / "mods.control.meta"
+    _write_manifest(fixture, [mod])
+
+    errors = validate_manifest(fixture, "openmw")
+
+    assert any("priority" in error for error in errors)
+
+
+@pytest.mark.parametrize(
+    "url",
+    ["nexusmods.com/morrowind/mods/1", "ftp://example.com/mod", "https://exa mple.com"],
+)
+def test_malformed_manifest_url_fails(tmp_path: Path, url: str) -> None:
+    mod = dict(FIXTURE_REQUIRED_FIELDS)
+    mod["url"] = url
+    fixture = tmp_path / "mods.control.meta"
+    _write_manifest(fixture, [mod])
+
+    errors = validate_manifest(fixture, "openmw")
+
+    assert any("malformed url" in error for error in errors)
+
+
+def test_honest_planned_placeholder_passes(tmp_path: Path) -> None:
+    fixture = tmp_path / "mods.control.meta"
+    _write_manifest(fixture, [dict(FIXTURE_REQUIRED_FIELDS)])
+
+    assert validate_manifest(fixture, "openmw") == []
+
+
+def test_testing_status_rejects_placeholder_evidence(tmp_path: Path) -> None:
+    mod = dict(FIXTURE_REQUIRED_FIELDS)
+    mod["status"] = "testing"
+    fixture = tmp_path / "mods.control.meta"
+    _write_manifest(fixture, [mod])
+
+    errors = validate_manifest(fixture, "openmw")
+
+    joined = "\n".join(errors)
+    assert "requires a verified 'source'" in joined
+    assert "requires a verified 'url'" in joined
+    assert "requires non-placeholder 'archive_name' evidence" in joined
+    assert "requires non-placeholder 'version' evidence" in joined
+    assert "requires non-placeholder 'testing_notes' evidence" in joined
+    assert "requires reviewed_by" in joined
+    assert "requires last_reviewed" in joined
+
+
+def test_testing_status_with_concrete_evidence_passes(tmp_path: Path) -> None:
+    mod = dict(FIXTURE_REQUIRED_FIELDS)
+    mod.update(
+        {
+            "status": "testing",
+            "source": "nexus",
+            "url": "https://www.nexusmods.com/morrowind/mods/1",
+            "archive_name": "sample.7z",
+            "version": "1.0",
+            "testing_notes": "Smoke test completed on the documented route.",
+            "decision_reason": "Maintainer approved this entry for the test queue.",
+            "reviewed_by": ["Maintainer A"],
+            "last_reviewed": "2026-07-17",
+        }
+    )
+    fixture = tmp_path / "mods.control.meta"
+    _write_manifest(fixture, [mod])
+
+    assert validate_manifest(fixture, "openmw") == []
+
+
+@pytest.mark.parametrize(
+    "testing_notes",
+    ["Not tested.", "No repository test evidence is recorded.", "Testing pending."],
+)
+def test_testing_status_rejects_explicit_non_test_evidence(
+    tmp_path: Path, testing_notes: str
+) -> None:
+    mod = dict(FIXTURE_REQUIRED_FIELDS)
+    mod.update(
+        {
+            "status": "testing",
+            "source": "nexus",
+            "url": "https://www.nexusmods.com/morrowind/mods/1",
+            "archive_name": "sample.7z",
+            "version": "1.0",
+            "testing_notes": testing_notes,
+            "decision_reason": "Maintainer approved this entry for the test queue.",
+            "reviewed_by": ["Maintainer A"],
+            "last_reviewed": "2026-07-17",
+        }
+    )
+    fixture = tmp_path / "mods.control.meta"
+    _write_manifest(fixture, [mod])
+
+    errors = validate_manifest(fixture, "openmw")
+
+    assert any("requires non-placeholder 'testing_notes' evidence" in error for error in errors)
+
+
+def test_testing_status_rejects_placeholder_reviewer(tmp_path: Path) -> None:
+    mod = dict(FIXTURE_REQUIRED_FIELDS)
+    mod.update(
+        {
+            "status": "testing",
+            "source": "nexus",
+            "url": "https://www.nexusmods.com/morrowind/mods/1",
+            "archive_name": "sample.7z",
+            "version": "1.0",
+            "testing_notes": "Documented smoke-test route passed.",
+            "decision_reason": "Maintainer approved this entry for the test queue.",
+            "reviewed_by": ["TBD"],
+            "last_reviewed": "2026-07-17",
+        }
+    )
+    fixture = tmp_path / "mods.control.meta"
+    _write_manifest(fixture, [mod])
+
+    errors = validate_manifest(fixture, "openmw")
+
+    assert any("reviewed_by' must be non-placeholder" in error for error in errors)
+    assert any("status 'testing' requires reviewed_by" in error for error in errors)
+
+
+@pytest.mark.parametrize("status", ["rejected", "needs-patch", "deprecated"])
+def test_decision_status_requires_rationale(tmp_path: Path, status: str) -> None:
+    mod = dict(FIXTURE_REQUIRED_FIELDS)
+    mod.update({"status": status, "decision_reason": "TBD"})
+    fixture = tmp_path / "mods.control.meta"
+    _write_manifest(fixture, [mod])
+
+    errors = validate_manifest(fixture, "openmw")
+
+    assert any("requires non-placeholder 'decision_reason' rationale" in error for error in errors)
+    if status == "rejected":
+        assert any("status 'rejected' requires reviewed_by" in error for error in errors)
+        assert any("status 'rejected' requires last_reviewed" in error for error in errors)
+
+
+def test_accepted_status_requires_canonical_source_reference(tmp_path: Path) -> None:
+    mod = dict(FIXTURE_REQUIRED_FIELDS)
+    mod.update(
+        {
+            "status": "accepted",
+            "source": "nexus",
+            "url": "https://www.nexusmods.com/morrowind/mods/1",
+            "archive_name": "sample.7z",
+            "version": "1.0",
+            "testing_notes": "Compatibility route completed without observed blockers.",
+            "decision_reason": "Maintainer reviewed the recorded evidence.",
+            "reviewed_by": ["Maintainer A"],
+            "last_reviewed": "2026-07-17",
+        }
+    )
+    fixture = tmp_path / "mods.control.meta"
+    _write_manifest(fixture, [mod])
+
+    errors = validate_manifest(fixture, "openmw")
+
+    assert any("status 'accepted' requires source_reference" in error for error in errors)
+
+
+@pytest.mark.parametrize("field_name", ["requires", "conflicts", "load_after", "load_before"])
+def test_malformed_manifest_reference_fails(tmp_path: Path, field_name: str) -> None:
+    mod = dict(FIXTURE_REQUIRED_FIELDS)
+    mod[field_name] = ["Bad Reference"]
+    fixture = tmp_path / "mods.control.meta"
+    _write_manifest(fixture, [mod])
+
+    errors = validate_manifest(fixture, "openmw")
+
+    assert any(f"field '{field_name}' has malformed reference" in error for error in errors)
+
+
+@pytest.mark.parametrize("field_name", ["requires", "conflicts", "load_after", "load_before"])
+def test_nonexistent_manifest_reference_fails(tmp_path: Path, field_name: str) -> None:
+    mod = dict(FIXTURE_REQUIRED_FIELDS)
+    mod[field_name] = ["missing-mod"]
+    fixture = tmp_path / "mods.control.meta"
+    _write_manifest(fixture, [mod])
+
+    errors = validate_manifest(fixture, "openmw")
+
+    assert any("references nonexistent manifest id 'missing-mod'" in error for error in errors)
+
+
+def test_valid_manifest_reference_passes(tmp_path: Path) -> None:
+    required = dict(FIXTURE_REQUIRED_FIELDS)
+    dependent = dict(
+        FIXTURE_REQUIRED_FIELDS,
+        id="dependent-mod",
+        name="Dependent Mod",
+        priority=2,
+        requires=["sample-mod"],
+        load_after=["sample-mod"],
+    )
+    fixture = tmp_path / "mods.control.meta"
+    _write_manifest(fixture, [required, dependent])
+
+    assert validate_manifest(fixture, "openmw") == []
+
+
+def test_contradictory_manifest_references_fail(tmp_path: Path) -> None:
+    required = dict(FIXTURE_REQUIRED_FIELDS)
+    dependent = dict(
+        FIXTURE_REQUIRED_FIELDS,
+        id="dependent-mod",
+        name="Dependent Mod",
+        priority=2,
+        requires=["sample-mod"],
+        conflicts=["sample-mod"],
+        load_after=["sample-mod"],
+        load_before=["sample-mod"],
+    )
+    fixture = tmp_path / "mods.control.meta"
+    _write_manifest(fixture, [required, dependent])
+
+    errors = validate_manifest(fixture, "openmw")
+
+    joined = "\n".join(errors)
+    assert "both requires and conflicts" in joined
+    assert "both load_after and load_before" in joined
+
+
+def test_invalid_source_reference_shape_fails(tmp_path: Path) -> None:
+    mod = dict(FIXTURE_REQUIRED_FIELDS)
+    mod["source_reference"] = "Bad Source ID"
+    fixture = tmp_path / "mods.control.meta"
+    _write_manifest(fixture, [mod])
+
+    errors = validate_manifest(fixture, "openmw")
+
+    assert any("source_reference" in error for error in errors)
+
+
+def _canonical_candidate(**overrides: object) -> dict:
+    candidate = {
+        "id": "sample-candidate",
+        "name": "Sample Candidate",
+        "candidate_status": "candidate",
+        "thematic_bucket": "foundation",
+        "intended_editions": ["openmw"],
+        "engine_notes": "OpenMW evaluation remains pending.",
+        "source_type": "nexus",
+        "source_url": "https://www.nexusmods.com/morrowind/mods/1",
+        "source_confidence": "verified",
+        "compatibility_status": "needs-testing",
+        "evidence_notes": "The source page identifies the candidate.",
+        "thematic_reason": "Fixture",
+        "risk_level": "unknown",
+        "promotion_target": "openmw",
+        "promotion_notes": "",
+        "reviewed_by": [],
+        "last_reviewed": "",
+        "related_manifest_ids": ["sample-manifest-id"],
+    }
+    candidate.update(overrides)
+    return candidate
+
+
+def _linked_manifest(**overrides: object) -> dict:
+    mod = dict(
+        FIXTURE_REQUIRED_FIELDS,
+        id="sample-manifest-id",
+        name="Sample Candidate",
+        source_reference="sample-candidate",
+    )
+    mod.update(overrides)
+    return mod
+
+
+def _validate_source_link(mod: dict, candidate: dict) -> list[str]:
+    return validate_source_references(
+        {"openmw": [mod], "mwse": []},
+        {"openmw": Path("openmw.meta"), "mwse": Path("mwse.meta")},
+        [candidate],
+        Path("sourced.meta"),
+        ["openmw"],
+    )
+
+
+def test_valid_source_reference_passes() -> None:
+    assert _validate_source_link(_linked_manifest(), _canonical_candidate()) == []
+
+
+@pytest.mark.parametrize(
+    ("mod_overrides", "candidate_overrides", "expected"),
+    [
+        ({"name": "Wrong Name"}, {}, "name does not match"),
+        ({}, {"intended_editions": ["mwse"]}, "does not include edition"),
+        ({}, {"related_manifest_ids": []}, "does not link back"),
+        ({"source": "github"}, {}, "does not match canonical source_type"),
+        ({"url": "https://example.com/wrong"}, {}, "does not match canonical source_url"),
+    ],
+)
+def test_source_reference_mismatches_fail(
+    mod_overrides: dict,
+    candidate_overrides: dict,
+    expected: str,
+) -> None:
+    errors = _validate_source_link(
+        _linked_manifest(**mod_overrides),
+        _canonical_candidate(**candidate_overrides),
+    )
+
+    assert any(expected in error for error in errors)
+
+
+def test_nonexistent_source_reference_fails() -> None:
+    mod = _linked_manifest(source_reference="missing-source")
+
+    errors = _validate_source_link(mod, _canonical_candidate())
+
+    assert any("does not exist" in error for error in errors)
+
+
+def test_nonexistent_related_manifest_id_fails() -> None:
+    candidate = _canonical_candidate(related_manifest_ids=["missing-manifest"])
+
+    errors = _validate_source_link(_linked_manifest(), candidate)
+
+    assert any("references nonexistent manifest id" in error for error in errors)
+
+
+def test_planning_source_link_is_independent_of_promotion_target() -> None:
+    candidate = _canonical_candidate(promotion_target="mwse")
+
+    assert _validate_source_link(_linked_manifest(), candidate) == []
+
+
+def test_accepted_source_link_requires_matching_promotion_target() -> None:
+    mod = _linked_manifest(status="accepted")
+    candidate = _canonical_candidate(
+        candidate_status="promoted",
+        compatibility_status="openmw-compatible",
+        promotion_target="mwse",
+    )
+
+    errors = _validate_source_link(mod, candidate)
+
+    assert any("promotion_target to include edition 'openmw'" in error for error in errors)
+
+
+def test_reverse_source_link_rejects_wrong_edition_only_match() -> None:
+    wrong_edition_mod = _linked_manifest(edition="mwse", engine=["mwse"])
+    wrong_edition_mod.pop("source_reference")
+    candidate = _canonical_candidate(intended_editions=["openmw"])
+
+    errors = validate_source_references(
+        {"openmw": [], "mwse": [wrong_edition_mod]},
+        {"openmw": Path("openmw.meta"), "mwse": Path("mwse.meta")},
+        [candidate],
+        Path("sourced.meta"),
+        ["mwse"],
+    )
+
+    assert any("resolves only to unintended editions" in error for error in errors)
+
+
+def test_empty_source_registry_does_not_bypass_manifest_links(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    manifest_paths = {
+        "openmw": tmp_path / "openmw.control.meta",
+        "mwse": tmp_path / "mwse.control.meta",
+    }
+    _write_manifest(manifest_paths["openmw"], [_linked_manifest()])
+    _write_manifest(manifest_paths["mwse"], [])
+    source_path = tmp_path / "sourced-mods.control.meta"
+    source_path.write_text("sourced_candidates: []\n", encoding="utf-8")
+    monkeypatch.setattr(
+        manifest_validator, "manifest_path", lambda edition: manifest_paths[edition]
+    )
+
+    errors = manifest_validator.validate_repository(["openmw"], source_path)
+
+    assert any("source_reference 'sample-candidate' does not exist" in error for error in errors)

--- a/ash-archive/tools/check_duplicate_mods.py
+++ b/ash-archive/tools/check_duplicate_mods.py
@@ -56,12 +56,12 @@ def find_cross_edition_name_mismatches(
     return warnings
 
 
-def _load_mods_for_path(path: Path) -> list[dict]:
+def _load_mods_for_path(path: Path) -> tuple[list[dict], bool]:
     try:
-        return load_mods(path)
+        return load_mods(path), False
     except ValueError as exc:
         print(f"[ERROR] {exc}")
-        return []
+        return [], True
 
 
 def main() -> int:
@@ -70,7 +70,8 @@ def main() -> int:
 
     for edition in EDITIONS:
         path = manifest_path(edition)
-        mods = _load_mods_for_path(path)
+        mods, load_failed = _load_mods_for_path(path)
+        has_errors = has_errors or load_failed
         mods_by_edition[edition] = mods
         report = find_duplicates(mods)
 

--- a/ash-archive/tools/compare_editions.py
+++ b/ash-archive/tools/compare_editions.py
@@ -6,6 +6,22 @@ from lib.paths import manifest_path
 from lib.validation import validate_manifest
 
 
+def find_cross_status_mismatches(openmw: dict[str, dict], mwse: dict[str, dict]) -> list[str]:
+    shared = set(openmw) & set(mwse)
+    return sorted(
+        mod_id
+        for mod_id in shared
+        if openmw[mod_id].get("cross_edition_status") != mwse[mod_id].get("cross_edition_status")
+    )
+
+
+def find_cross_name_mismatches(openmw: dict[str, dict], mwse: dict[str, dict]) -> list[str]:
+    shared = set(openmw) & set(mwse)
+    return sorted(
+        mod_id for mod_id in shared if openmw[mod_id].get("name") != mwse[mod_id].get("name")
+    )
+
+
 def main() -> int:
     errs = []
     errs.extend(validate_manifest(manifest_path("openmw"), "openmw"))
@@ -33,11 +49,8 @@ def main() -> int:
         for mod_id, mod in {**openmw, **mwse}.items()
         if mod.get("cross_edition_status") == "different-implementation"
     )
-    mismatched = sorted(
-        mod_id
-        for mod_id in shared
-        if openmw[mod_id].get("cross_edition_status") != mwse[mod_id].get("cross_edition_status")
-    )
+    mismatched = find_cross_status_mismatches(openmw, mwse)
+    name_mismatched = find_cross_name_mismatches(openmw, mwse)
 
     print("Shared IDs:", ", ".join(shared) or "(none)")
     print("OpenMW-only IDs:", ", ".join(open_only) or "(none)")
@@ -45,6 +58,13 @@ def main() -> int:
     print("IDs marked equivalent-needed:", ", ".join(equiv) or "(none)")
     print("IDs marked different-implementation:", ", ".join(diff_impl) or "(none)")
     print("Mismatched cross_edition_status:", ", ".join(mismatched) or "(none)")
+    print("Mismatched shared-ID names:", ", ".join(name_mismatched) or "(none)")
+    if mismatched or name_mismatched:
+        if mismatched:
+            print("[ERROR] Shared manifest IDs must use the same cross_edition_status.")
+        if name_mismatched:
+            print("[ERROR] Shared manifest IDs must represent the same named identity.")
+        return 1
     return 0
 
 

--- a/ash-archive/tools/generate_modlist_markdown.py
+++ b/ash-archive/tools/generate_modlist_markdown.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import argparse
+import difflib
 from pathlib import Path
 
 from lib.manifest import load_mods
@@ -12,29 +13,66 @@ START = "<!-- GENERATED-CONTENT:START -->"
 END = "<!-- GENERATED-CONTENT:END -->"
 
 
-def update_modlist(path: Path, content: str) -> None:
-    text = path.read_text(encoding="utf-8") if path.exists() else "# Modlist\n\n"
-    if START in text and END in text:
-        pre = text.split(START)[0]
-        post = text.split(END)[1]
-        new_text = f"{pre}{START}\n{content}{END}{post}"
-    else:
-        new_text = f"{text.rstrip()}\n\n{START}\n{content}{END}\n"
-    path.write_text(new_text, encoding="utf-8")
+def render_modlist_document(text: str, content: str) -> str:
+    start_count = text.count(START)
+    end_count = text.count(END)
+    if start_count != end_count or start_count > 1:
+        raise ValueError("MODLIST.md must contain exactly one balanced generated marker pair")
+
+    if start_count == 1:
+        start_index = text.index(START)
+        end_index = text.index(END)
+        if end_index < start_index:
+            raise ValueError("MODLIST.md generated markers are out of order")
+        pre = text[:start_index]
+        post = text[end_index + len(END) :]
+        return f"{pre}{START}\n{content}{END}{post}"
+
+    return f"{text.rstrip()}\n\n{START}\n{content}{END}\n"
+
+
+def expected_modlist(path: Path, content: str) -> tuple[str, str]:
+    current = path.read_text(encoding="utf-8") if path.exists() else "# Modlist\n\n"
+    return current, render_modlist_document(current, content)
+
+
+def report_diff(path: Path, current: str, expected: str) -> None:
+    diff = difflib.unified_diff(
+        current.splitlines(keepends=True),
+        expected.splitlines(keepends=True),
+        fromfile=str(path),
+        tofile=f"{path} (generated)",
+    )
+    print("".join(diff), end="")
 
 
 def main() -> int:
     parser = argparse.ArgumentParser(description="Generate MODLIST markdown from manifests.")
     parser.add_argument("--edition", choices=EDITIONS)
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Fail and print a diff when committed MODLIST files are stale; do not write files.",
+    )
     args = parser.parse_args()
     editions = [args.edition] if args.edition else list(EDITIONS)
+    stale = False
     for edition in editions:
         mods = load_mods(ROOT / "editions" / edition / "manifests" / "mods.control.meta")
         body = render_mod_sections(mods)
         modlist_path = ROOT / "editions" / edition / "MODLIST.md"
-        update_modlist(modlist_path, body)
-        print(f"Updated {modlist_path}")
-    return 0
+        current, expected = expected_modlist(modlist_path, body)
+        if current == expected:
+            print(f"[OK] Current: {modlist_path}")
+            continue
+        if args.check:
+            stale = True
+            print(f"[ERROR] Stale generated file: {modlist_path}")
+            report_diff(modlist_path, current, expected)
+        else:
+            modlist_path.write_text(expected, encoding="utf-8")
+            print(f"Updated {modlist_path}")
+    return int(stale)
 
 
 if __name__ == "__main__":

--- a/ash-archive/tools/lib/sourced_mods.py
+++ b/ash-archive/tools/lib/sourced_mods.py
@@ -1,11 +1,10 @@
 from __future__ import annotations
 
-import re
+from datetime import date
 from pathlib import Path
 
 from .manifest import load_meta_document
-
-ID_RE = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
+from .validation import ID_RE, _format_error, _is_placeholder, _is_valid_url
 
 REQUIRED_FIELDS = [
     "id",
@@ -56,12 +55,23 @@ COMPATIBILITY_STATUS = {
     "needs-testing",
     "conflicting-reports",
 }
+EVIDENCED_COMPATIBILITY_STATUS = {
+    "openmw-compatible",
+    "mwse-compatible",
+    "both-compatible",
+    "incompatible",
+}
 RISK_LEVELS = {"low", "medium", "high", "unknown"}
 PROMOTION_TARGETS = {"openmw", "mwse", "both", "neither", "undecided"}
-
-
-def _format_error(path: Path, mod_ref: str, detail: str) -> str:
-    return f"[ERROR] {path} :: {mod_ref} :: {detail}"
+STRING_FIELDS = {
+    "name",
+    "engine_notes",
+    "source_url",
+    "evidence_notes",
+    "thematic_reason",
+    "promotion_notes",
+    "last_reviewed",
+}
 
 
 def _mod_ref(candidate: dict) -> str:
@@ -74,10 +84,233 @@ def _mod_ref(candidate: dict) -> str:
     return "<missing-id>"
 
 
-def _validate_string_field(candidate: dict, field_name: str, path: Path, mod_ref: str) -> list[str]:
-    if not isinstance(candidate[field_name], str):
-        return [_format_error(path, mod_ref, f"field '{field_name}' must be a string")]
+def _validate_enum(
+    candidate: dict,
+    field_name: str,
+    allowed: set[str],
+    path: Path,
+    mod_ref: str,
+) -> list[str]:
+    value = candidate[field_name]
+    if not isinstance(value, str) or value not in allowed:
+        return [_format_error(path, mod_ref, f"invalid {field_name} {value!r}")]
     return []
+
+
+def _has_review(candidate: dict) -> bool:
+    reviewers = candidate.get("reviewed_by")
+    return (
+        isinstance(reviewers, list)
+        and any(
+            isinstance(reviewer, str) and not _is_placeholder(reviewer) for reviewer in reviewers
+        )
+        and isinstance(candidate.get("last_reviewed"), str)
+        and bool(candidate["last_reviewed"].strip())
+    )
+
+
+def _validate_review_fields(candidate: dict, path: Path, mod_ref: str) -> list[str]:
+    errors: list[str] = []
+    reviewed_by = candidate["reviewed_by"]
+    if not isinstance(reviewed_by, list) or any(
+        not isinstance(reviewer, str) or _is_placeholder(reviewer) for reviewer in reviewed_by
+    ):
+        errors.append(
+            _format_error(path, mod_ref, "field 'reviewed_by' must be non-placeholder list[str]")
+        )
+    elif len(reviewed_by) != len(set(reviewed_by)):
+        errors.append(_format_error(path, mod_ref, "field 'reviewed_by' contains duplicates"))
+
+    last_reviewed = candidate["last_reviewed"]
+    if isinstance(last_reviewed, str) and last_reviewed:
+        try:
+            parsed = date.fromisoformat(last_reviewed)
+        except ValueError:
+            parsed = None
+        if parsed is None or parsed.isoformat() != last_reviewed:
+            errors.append(_format_error(path, mod_ref, "field 'last_reviewed' must use YYYY-MM-DD"))
+    return errors
+
+
+def _validate_lists(candidate: dict, path: Path, mod_ref: str) -> list[str]:
+    errors: list[str] = []
+    intended_editions = candidate["intended_editions"]
+    if not isinstance(intended_editions, list) or not intended_editions:
+        errors.append(
+            _format_error(path, mod_ref, "field 'intended_editions' must be a non-empty list")
+        )
+    elif any(not isinstance(edition, str) for edition in intended_editions):
+        errors.append(_format_error(path, mod_ref, "field 'intended_editions' must be list[str]"))
+    else:
+        invalid_editions = [
+            edition for edition in intended_editions if edition not in INTENDED_EDITIONS
+        ]
+        if invalid_editions:
+            errors.append(
+                _format_error(
+                    path, mod_ref, f"invalid intended_editions values {invalid_editions!r}"
+                )
+            )
+        if len(intended_editions) != len(set(intended_editions)):
+            errors.append(
+                _format_error(path, mod_ref, "field 'intended_editions' contains duplicates")
+            )
+
+    related_manifest_ids = candidate["related_manifest_ids"]
+    if not isinstance(related_manifest_ids, list) or any(
+        not isinstance(manifest_id, str) for manifest_id in related_manifest_ids
+    ):
+        errors.append(
+            _format_error(path, mod_ref, "field 'related_manifest_ids' must be list[str]")
+        )
+    else:
+        if len(related_manifest_ids) != len(set(related_manifest_ids)):
+            errors.append(
+                _format_error(path, mod_ref, "field 'related_manifest_ids' contains duplicates")
+            )
+        for manifest_id in related_manifest_ids:
+            if not ID_RE.fullmatch(manifest_id):
+                errors.append(
+                    _format_error(
+                        path,
+                        mod_ref,
+                        f"field 'related_manifest_ids' has malformed reference {manifest_id!r}",
+                    )
+                )
+    return errors
+
+
+def _validate_candidate_consistency(candidate: dict, path: Path, mod_ref: str) -> list[str]:
+    errors: list[str] = []
+    source_url = candidate["source_url"]
+    if isinstance(source_url, str) and source_url.strip() and not _is_valid_url(source_url):
+        errors.append(
+            _format_error(
+                path, mod_ref, f"malformed source_url {source_url!r}; expected http(s) URL"
+            )
+        )
+
+    source_confidence = candidate["source_confidence"]
+    if source_confidence == "verified":
+        if (
+            not isinstance(source_url, str)
+            or not source_url.strip()
+            or not _is_valid_url(source_url)
+        ):
+            errors.append(
+                _format_error(
+                    path, mod_ref, "source_confidence 'verified' requires a valid source_url"
+                )
+            )
+        if candidate["source_type"] == "unknown":
+            errors.append(
+                _format_error(
+                    path, mod_ref, "source_confidence 'verified' cannot use source_type 'unknown'"
+                )
+            )
+        if _is_placeholder(candidate["evidence_notes"]):
+            errors.append(
+                _format_error(path, mod_ref, "source_confidence 'verified' requires evidence_notes")
+            )
+
+    compatibility_status = candidate["compatibility_status"]
+    if compatibility_status in EVIDENCED_COMPATIBILITY_STATUS:
+        if _is_placeholder(candidate["evidence_notes"]) or _is_placeholder(
+            candidate["engine_notes"]
+        ):
+            errors.append(
+                _format_error(
+                    path,
+                    mod_ref,
+                    f"compatibility_status {compatibility_status!r} requires evidence and engine notes",
+                )
+            )
+        if not _has_review(candidate):
+            errors.append(
+                _format_error(
+                    path,
+                    mod_ref,
+                    f"compatibility_status {compatibility_status!r} requires review information",
+                )
+            )
+
+    intended_editions = candidate["intended_editions"]
+    if isinstance(intended_editions, list):
+        required_compatibility_editions = {
+            "openmw-compatible": {"openmw"},
+            "mwse-compatible": {"mwse"},
+            "both-compatible": {"openmw", "mwse"},
+        }.get(compatibility_status, set())
+        missing = required_compatibility_editions - set(intended_editions)
+        if missing:
+            errors.append(
+                _format_error(
+                    path,
+                    mod_ref,
+                    f"compatibility_status {compatibility_status!r} contradicts intended_editions",
+                )
+            )
+
+        promotion_target = candidate["promotion_target"]
+        required_target_editions = {
+            "openmw": {"openmw"},
+            "mwse": {"mwse"},
+            "both": {"openmw", "mwse"},
+        }.get(promotion_target, set())
+        if required_target_editions - set(intended_editions):
+            errors.append(
+                _format_error(
+                    path,
+                    mod_ref,
+                    f"promotion_target {promotion_target!r} contradicts intended_editions",
+                )
+            )
+
+    candidate_status = candidate["candidate_status"]
+    if candidate_status == "promoted":
+        if candidate["promotion_target"] in {"neither", "undecided"}:
+            errors.append(
+                _format_error(
+                    path,
+                    mod_ref,
+                    "candidate_status 'promoted' requires a concrete promotion_target",
+                )
+            )
+        related_ids = candidate["related_manifest_ids"]
+        if not isinstance(related_ids, list) or not related_ids:
+            errors.append(
+                _format_error(
+                    path, mod_ref, "candidate_status 'promoted' requires related_manifest_ids"
+                )
+            )
+        if _is_placeholder(candidate["promotion_notes"]):
+            errors.append(
+                _format_error(path, mod_ref, "candidate_status 'promoted' requires promotion_notes")
+            )
+        if not _has_review(candidate):
+            errors.append(
+                _format_error(
+                    path, mod_ref, "candidate_status 'promoted' requires review information"
+                )
+            )
+    elif candidate_status in {"rejected", "superseded"}:
+        if _is_placeholder(candidate["promotion_notes"]):
+            errors.append(
+                _format_error(
+                    path,
+                    mod_ref,
+                    f"candidate_status {candidate_status!r} requires promotion_notes",
+                )
+            )
+        if not _has_review(candidate):
+            errors.append(
+                _format_error(
+                    path,
+                    mod_ref,
+                    f"candidate_status {candidate_status!r} requires review information",
+                )
+            )
+    return errors
 
 
 def validate_candidate(candidate: dict, path: Path) -> list[str]:
@@ -96,78 +329,27 @@ def validate_candidate(candidate: dict, path: Path) -> list[str]:
             _format_error(path, mod_ref, f"invalid id {mod_id!r}; expected lowercase kebab-case")
         )
 
-    errors.extend(_validate_string_field(candidate, "name", path, mod_ref))
-    errors.extend(_validate_string_field(candidate, "engine_notes", path, mod_ref))
-    errors.extend(_validate_string_field(candidate, "source_url", path, mod_ref))
-    errors.extend(_validate_string_field(candidate, "evidence_notes", path, mod_ref))
-    errors.extend(_validate_string_field(candidate, "thematic_reason", path, mod_ref))
-    errors.extend(_validate_string_field(candidate, "promotion_notes", path, mod_ref))
-    errors.extend(_validate_string_field(candidate, "last_reviewed", path, mod_ref))
+    for field_name in STRING_FIELDS:
+        if not isinstance(candidate[field_name], str):
+            errors.append(_format_error(path, mod_ref, f"field '{field_name}' must be a string"))
+    if isinstance(candidate["name"], str) and not candidate["name"].strip():
+        errors.append(_format_error(path, mod_ref, "field 'name' must not be blank"))
 
-    if candidate["candidate_status"] not in CANDIDATE_STATUS:
-        errors.append(
-            _format_error(
-                path, mod_ref, f"invalid candidate_status {candidate['candidate_status']!r}"
-            )
-        )
-    if candidate["thematic_bucket"] not in THEMATIC_BUCKETS:
-        errors.append(
-            _format_error(
-                path, mod_ref, f"invalid thematic_bucket {candidate['thematic_bucket']!r}"
-            )
-        )
-    if candidate["source_type"] not in SOURCE_TYPES:
-        errors.append(
-            _format_error(path, mod_ref, f"invalid source_type {candidate['source_type']!r}")
-        )
-    if candidate["source_confidence"] not in SOURCE_CONFIDENCE:
-        errors.append(
-            _format_error(
-                path, mod_ref, f"invalid source_confidence {candidate['source_confidence']!r}"
-            )
-        )
-    if candidate["compatibility_status"] not in COMPATIBILITY_STATUS:
-        errors.append(
-            _format_error(
-                path,
-                mod_ref,
-                f"invalid compatibility_status {candidate['compatibility_status']!r}",
-            )
-        )
-    if candidate["risk_level"] not in RISK_LEVELS:
-        errors.append(
-            _format_error(path, mod_ref, f"invalid risk_level {candidate['risk_level']!r}")
-        )
-    if candidate["promotion_target"] not in PROMOTION_TARGETS:
-        errors.append(
-            _format_error(
-                path, mod_ref, f"invalid promotion_target {candidate['promotion_target']!r}"
-            )
-        )
+    errors.extend(_validate_enum(candidate, "candidate_status", CANDIDATE_STATUS, path, mod_ref))
+    errors.extend(_validate_enum(candidate, "thematic_bucket", THEMATIC_BUCKETS, path, mod_ref))
+    errors.extend(_validate_enum(candidate, "source_type", SOURCE_TYPES, path, mod_ref))
+    errors.extend(_validate_enum(candidate, "source_confidence", SOURCE_CONFIDENCE, path, mod_ref))
+    errors.extend(
+        _validate_enum(candidate, "compatibility_status", COMPATIBILITY_STATUS, path, mod_ref)
+    )
+    errors.extend(_validate_enum(candidate, "risk_level", RISK_LEVELS, path, mod_ref))
+    errors.extend(_validate_enum(candidate, "promotion_target", PROMOTION_TARGETS, path, mod_ref))
+    errors.extend(_validate_lists(candidate, path, mod_ref))
+    errors.extend(_validate_review_fields(candidate, path, mod_ref))
 
-    intended_editions = candidate["intended_editions"]
-    if not isinstance(intended_editions, list) or not intended_editions:
-        errors.append(
-            _format_error(path, mod_ref, "field 'intended_editions' must be a non-empty list")
-        )
-    elif any(not isinstance(edition, str) for edition in intended_editions):
-        errors.append(_format_error(path, mod_ref, "field 'intended_editions' must be list[str]"))
-    else:
-        invalid_editions = [
-            edition for edition in intended_editions if edition not in INTENDED_EDITIONS
-        ]
-        if invalid_editions:
-            errors.append(
-                _format_error(
-                    path, mod_ref, f"invalid intended_editions values {invalid_editions!r}"
-                )
-            )
-
-    for field_name in ("reviewed_by", "related_manifest_ids"):
-        value = candidate[field_name]
-        if not isinstance(value, list) or any(not isinstance(item, str) for item in value):
-            errors.append(_format_error(path, mod_ref, f"field '{field_name}' must be list[str]"))
-
+    # Consistency checks assume the relevant scalar enum and string fields are well-typed.
+    if not any("must be a string" in error or "invalid " in error for error in errors):
+        errors.extend(_validate_candidate_consistency(candidate, path, mod_ref))
     return errors
 
 
@@ -186,9 +368,18 @@ def validate_sourced_mods(path: Path) -> tuple[list[dict], list[str]]:
         return [], [f"[ERROR] {exc}"]
 
     errors: list[str] = []
+    seen_ids: set[str] = set()
+    duplicate_ids: set[str] = set()
     for candidate in candidates:
         if not isinstance(candidate, dict):
             errors.append(f"[ERROR] {path} :: <entry> :: non-object entry in sourced_candidates")
             continue
+        candidate_id = candidate.get("id")
+        if isinstance(candidate_id, str):
+            if candidate_id in seen_ids:
+                duplicate_ids.add(candidate_id)
+            seen_ids.add(candidate_id)
         errors.extend(validate_candidate(candidate, path))
+    for candidate_id in sorted(duplicate_ids):
+        errors.append(_format_error(path, candidate_id, "duplicate id in sourced candidates"))
     return candidates, errors

--- a/ash-archive/tools/lib/validation.py
+++ b/ash-archive/tools/lib/validation.py
@@ -1,13 +1,24 @@
 from __future__ import annotations
 
 import re
+from collections import defaultdict
+from collections.abc import Collection, Mapping
+from datetime import date
 from functools import lru_cache
 from pathlib import Path
+from urllib.parse import urlsplit
 
 from .manifest import load_meta_document, load_mods
 from .paths import categories_path
 
 ID_RE = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
+PLACEHOLDER_RE = re.compile(
+    r"\b(?:tbd|todo|placeholder|unknown|unverified|"
+    r"needs? (?:verification|testing|review|confirmation)|"
+    r"pending (?:verification|review|testing)|testing (?:is )?pending|"
+    r"not (?:yet )?tested|untested|no [^.\n]*test evidence [^.\n]*recorded)\b",
+    re.IGNORECASE,
+)
 CROSS = {
     "shared",
     "openmw-only",
@@ -47,6 +58,9 @@ REQ_FIELDS = [
 STR_FIELDS = [
     "name",
     "category",
+    "edition",
+    "cross_edition_status",
+    "status",
     "source",
     "url",
     "archive_name",
@@ -56,6 +70,14 @@ STR_FIELDS = [
     "decision_reason",
 ]
 LIST_FIELDS = ["plugin_files", "requires", "conflicts", "load_after", "load_before"]
+REFERENCE_FIELDS = ["requires", "conflicts", "load_after", "load_before"]
+VERIFIED_MANIFEST_STATUSES = {"testing", "accepted"}
+REVIEWED_MANIFEST_STATUSES = {*VERIFIED_MANIFEST_STATUSES, "rejected"}
+RATIONALE_REQUIRED_STATUSES = {"rejected", "needs-patch", "deprecated"}
+CROSS_STATUS_FORBIDDEN_BY_EDITION = {
+    "openmw": {"mwse-only", "rejected-in-openmw"},
+    "mwse": {"openmw-only", "rejected-in-mwse"},
+}
 
 
 def _format_error(path: Path, mod_ref: str, detail: str) -> str:
@@ -68,7 +90,7 @@ def _allowed_categories() -> frozenset[str]:
     cats = data.get("categories", [])
     if not isinstance(cats, list):
         raise ValueError(f"Top-level key 'categories' must be a list: {categories_path()}")
-    bad = [c for c in cats if not isinstance(c, str)]
+    bad = [category for category in cats if not isinstance(category, str)]
     if bad:
         raise ValueError(f"All categories must be strings in: {categories_path()}")
     return frozenset(cats)
@@ -84,6 +106,25 @@ def _mod_ref(mod: dict) -> str:
     return "<missing-id>"
 
 
+def _is_placeholder(value: object) -> bool:
+    if not isinstance(value, str):
+        return False
+    stripped = value.strip()
+    return not stripped or bool(PLACEHOLDER_RE.search(stripped))
+
+
+def _is_valid_url(value: str) -> bool:
+    if not value or any(character.isspace() for character in value):
+        return False
+    try:
+        parsed = urlsplit(value)
+        # Accessing port rejects malformed values such as ``:not-a-port``.
+        _ = parsed.port
+    except ValueError:
+        return False
+    return parsed.scheme in {"http", "https"} and bool(parsed.netloc) and bool(parsed.hostname)
+
+
 def _validate_enum_fields(mod: dict, path: Path, mod_ref: str, expected_edition: str) -> list[str]:
     errors: list[str] = []
     mod_id = mod.get("id")
@@ -95,48 +136,63 @@ def _validate_enum_fields(mod: dict, path: Path, mod_ref: str, expected_edition:
                 f"invalid id {mod_id!r}; expected lowercase kebab-case like 'patch-for-purists'",
             )
         )
-    if mod["edition"] != expected_edition:
+
+    edition = mod["edition"]
+    if not isinstance(edition, str) or edition != expected_edition:
         errors.append(
             _format_error(
                 path,
                 mod_ref,
-                f"edition mismatch: found {mod['edition']!r}, expected {expected_edition!r}",
+                f"edition mismatch: found {edition!r}, expected {expected_edition!r}",
             )
         )
-    if mod["cross_edition_status"] not in CROSS:
+
+    cross_edition_status = mod["cross_edition_status"]
+    if not isinstance(cross_edition_status, str) or cross_edition_status not in CROSS:
         errors.append(
             _format_error(
                 path,
                 mod_ref,
-                f"invalid cross_edition_status {mod['cross_edition_status']!r}",
+                f"invalid cross_edition_status {cross_edition_status!r}",
             )
         )
-    if mod["status"] not in STATUS:
-        errors.append(_format_error(path, mod_ref, f"invalid status {mod['status']!r}"))
+    elif cross_edition_status in CROSS_STATUS_FORBIDDEN_BY_EDITION[expected_edition]:
+        errors.append(
+            _format_error(
+                path,
+                mod_ref,
+                f"cross_edition_status {cross_edition_status!r} is incompatible with "
+                f"edition {expected_edition!r}",
+            )
+        )
+
+    status = mod["status"]
+    if not isinstance(status, str) or status not in STATUS:
+        errors.append(_format_error(path, mod_ref, f"invalid status {status!r}"))
+
+    category = mod["category"]
     allowed = _allowed_categories()
-    if mod["category"] not in allowed:
+    if not isinstance(category, str) or category not in allowed:
         errors.append(
             _format_error(
                 path,
                 mod_ref,
-                f"invalid category {mod['category']!r}; expected one of shared/categories.control.meta",
+                f"invalid category {category!r}; expected one of shared/categories.control.meta",
             )
         )
     return errors
 
 
 def _validate_engine_field(mod: dict, path: Path, mod_ref: str, expected_edition: str) -> list[str]:
-    errors: list[str] = []
     engine = mod["engine"]
-    if not isinstance(engine, list):
+    if not isinstance(engine, list) or any(not isinstance(value, str) for value in engine):
         return [_format_error(path, mod_ref, "field 'engine' must be list[str]")]
     if not engine:
         return [_format_error(path, mod_ref, "engine must be a non-empty list")]
-    if any(not isinstance(e, str) for e in engine):
-        return [_format_error(path, mod_ref, "field 'engine' must be list[str]")]
 
+    errors: list[str] = []
     allowed = ENGINE_BY_EDITION[expected_edition]
-    invalid = [e for e in engine if e not in allowed]
+    invalid = [value for value in engine if value not in allowed]
     if invalid:
         errors.append(
             _format_error(
@@ -146,22 +202,16 @@ def _validate_engine_field(mod: dict, path: Path, mod_ref: str, expected_edition
             )
         )
 
+    if len(engine) != len(set(engine)):
+        errors.append(_format_error(path, mod_ref, "engine contains duplicate values"))
     unique_values = set(engine)
     if "unknown" in unique_values and len(unique_values) > 1:
         errors.append(
-            _format_error(
-                path,
-                mod_ref,
-                "engine cannot combine 'unknown' with other values",
-            )
+            _format_error(path, mod_ref, "engine cannot combine 'unknown' with other values")
         )
     if "both" in unique_values and len(unique_values) > 1:
         errors.append(
-            _format_error(
-                path,
-                mod_ref,
-                "engine cannot combine 'both' with other values",
-            )
+            _format_error(path, mod_ref, "engine cannot combine 'both' with other values")
         )
     return errors
 
@@ -176,13 +226,109 @@ def _validate_field_types(mod: dict, path: Path, mod_ref: str, expected_edition:
     for field_name in STR_FIELDS:
         if not isinstance(mod[field_name], str):
             errors.append(_format_error(path, mod_ref, f"field '{field_name}' must be a string"))
-    if not isinstance(mod["priority"], int):
+    if isinstance(mod["name"], str) and not mod["name"].strip():
+        errors.append(_format_error(path, mod_ref, "field 'name' must not be blank"))
+    priority = mod["priority"]
+    if isinstance(priority, bool) or not isinstance(priority, int):
         errors.append(_format_error(path, mod_ref, "field 'priority' must be integer"))
+    elif priority < 1:
+        errors.append(_format_error(path, mod_ref, "field 'priority' must be a positive integer"))
+
+    source_reference = mod.get("source_reference")
+    if source_reference is not None and (
+        not isinstance(source_reference, str) or not ID_RE.fullmatch(source_reference)
+    ):
+        errors.append(
+            _format_error(
+                path,
+                mod_ref,
+                "field 'source_reference' must be a lowercase kebab-case source id",
+            )
+        )
+    return errors
+
+
+def _validate_url_and_evidence(mod: dict, path: Path, mod_ref: str) -> list[str]:
+    errors: list[str] = []
+    url = mod["url"]
+    if isinstance(url, str) and url.strip() and not _is_placeholder(url) and not _is_valid_url(url):
+        errors.append(_format_error(path, mod_ref, f"malformed url {url!r}; expected http(s) URL"))
+
+    status = mod["status"]
+    if status in RATIONALE_REQUIRED_STATUSES and _is_placeholder(mod["decision_reason"]):
+        errors.append(
+            _format_error(
+                path,
+                mod_ref,
+                f"status {status!r} requires non-placeholder 'decision_reason' rationale",
+            )
+        )
+    if not isinstance(status, str) or status not in VERIFIED_MANIFEST_STATUSES:
+        return errors
+
+    source_reference = mod.get("source_reference")
+    if status == "accepted" and not (
+        isinstance(source_reference, str) and ID_RE.fullmatch(source_reference)
+    ):
+        errors.append(_format_error(path, mod_ref, "status 'accepted' requires source_reference"))
+    if source_reference is None:
+        for field_name in ("source", "url"):
+            if _is_placeholder(mod[field_name]):
+                errors.append(
+                    _format_error(
+                        path,
+                        mod_ref,
+                        f"status {status!r} requires a verified '{field_name}' or source_reference",
+                    )
+                )
+    for field_name in ("archive_name", "version", "testing_notes", "decision_reason"):
+        if _is_placeholder(mod[field_name]):
+            errors.append(
+                _format_error(
+                    path,
+                    mod_ref,
+                    f"status {status!r} requires non-placeholder '{field_name}' evidence",
+                )
+            )
+    return errors
+
+
+def _validate_review_metadata(mod: dict, path: Path, mod_ref: str) -> list[str]:
+    errors: list[str] = []
+    reviewed_by = mod.get("reviewed_by", [])
+    if not isinstance(reviewed_by, list) or any(
+        not isinstance(reviewer, str) or _is_placeholder(reviewer) for reviewer in reviewed_by
+    ):
+        errors.append(
+            _format_error(path, mod_ref, "field 'reviewed_by' must be non-placeholder list[str]")
+        )
+        reviewed_by = []
+    elif len(reviewed_by) != len(set(reviewed_by)):
+        errors.append(_format_error(path, mod_ref, "field 'reviewed_by' contains duplicates"))
+
+    last_reviewed = mod.get("last_reviewed", "")
+    valid_review_date = False
+    if not isinstance(last_reviewed, str):
+        errors.append(_format_error(path, mod_ref, "field 'last_reviewed' must be a string"))
+    elif last_reviewed:
+        try:
+            valid_review_date = date.fromisoformat(last_reviewed).isoformat() == last_reviewed
+        except ValueError:
+            valid_review_date = False
+        if not valid_review_date:
+            errors.append(_format_error(path, mod_ref, "field 'last_reviewed' must use YYYY-MM-DD"))
+
+    status = mod.get("status")
+    if status in REVIEWED_MANIFEST_STATUSES:
+        if not reviewed_by:
+            errors.append(_format_error(path, mod_ref, f"status {status!r} requires reviewed_by"))
+        if not valid_review_date:
+            errors.append(_format_error(path, mod_ref, f"status {status!r} requires last_reviewed"))
     return errors
 
 
 def validate_mod(mod: dict, path: Path, expected_edition: str) -> list[str]:
-    errors = []
+    errors: list[str] = []
     mod_ref = _mod_ref(mod)
     for field_name in REQ_FIELDS:
         if field_name not in mod:
@@ -191,10 +337,119 @@ def validate_mod(mod: dict, path: Path, expected_edition: str) -> list[str]:
         return errors
     errors.extend(_validate_enum_fields(mod, path, mod_ref, expected_edition))
     errors.extend(_validate_field_types(mod, path, mod_ref, expected_edition))
+    errors.extend(_validate_url_and_evidence(mod, path, mod_ref))
+    errors.extend(_validate_review_metadata(mod, path, mod_ref))
+    return errors
+
+
+def _validate_uniqueness(mods: list[dict], path: Path) -> list[str]:
+    errors: list[str] = []
+    ids: dict[str, list[str]] = defaultdict(list)
+    priorities: dict[tuple[str, int], list[str]] = defaultdict(list)
+    for mod in mods:
+        if not isinstance(mod, dict):
+            continue
+        mod_id = mod.get("id")
+        if isinstance(mod_id, str):
+            ids[mod_id].append(_mod_ref(mod))
+        category = mod.get("category")
+        priority = mod.get("priority")
+        if (
+            isinstance(category, str)
+            and isinstance(priority, int)
+            and not isinstance(priority, bool)
+        ):
+            priorities[(category, priority)].append(_mod_ref(mod))
+
+    for mod_id, references in sorted(ids.items()):
+        if len(references) > 1:
+            errors.append(_format_error(path, mod_id, "duplicate id in manifest"))
+    for (category, priority), references in sorted(priorities.items()):
+        if len(references) > 1:
+            errors.append(
+                _format_error(
+                    path,
+                    ", ".join(references),
+                    f"duplicate priority {priority} within category {category!r}",
+                )
+            )
+    return errors
+
+
+def _validate_references(mods: list[dict], path: Path) -> list[str]:
+    errors: list[str] = []
+    known_ids = {
+        mod["id"] for mod in mods if isinstance(mod, dict) and isinstance(mod.get("id"), str)
+    }
+    for mod in mods:
+        if not isinstance(mod, dict):
+            continue
+        mod_ref = _mod_ref(mod)
+        mod_id = mod.get("id")
+        valid_lists: dict[str, list[str]] = {}
+        for field_name in REFERENCE_FIELDS:
+            value = mod.get(field_name)
+            if not isinstance(value, list) or any(not isinstance(item, str) for item in value):
+                continue
+            valid_lists[field_name] = value
+            if len(value) != len(set(value)):
+                errors.append(
+                    _format_error(
+                        path, mod_ref, f"field '{field_name}' contains duplicate references"
+                    )
+                )
+            for reference in value:
+                if not ID_RE.fullmatch(reference):
+                    errors.append(
+                        _format_error(
+                            path,
+                            mod_ref,
+                            f"field '{field_name}' has malformed reference {reference!r}",
+                        )
+                    )
+                elif reference == mod_id:
+                    errors.append(
+                        _format_error(
+                            path, mod_ref, f"field '{field_name}' cannot reference itself"
+                        )
+                    )
+                elif reference not in known_ids:
+                    errors.append(
+                        _format_error(
+                            path,
+                            mod_ref,
+                            f"field '{field_name}' references nonexistent manifest id {reference!r}",
+                        )
+                    )
+
+        requires = set(valid_lists.get("requires", []))
+        conflicts = set(valid_lists.get("conflicts", []))
+        contradictory = sorted(requires & conflicts)
+        if contradictory:
+            errors.append(
+                _format_error(
+                    path,
+                    mod_ref,
+                    f"same ids cannot appear in both requires and conflicts: {contradictory!r}",
+                )
+            )
+        load_after = set(valid_lists.get("load_after", []))
+        load_before = set(valid_lists.get("load_before", []))
+        contradictory = sorted(load_after & load_before)
+        if contradictory:
+            errors.append(
+                _format_error(
+                    path,
+                    mod_ref,
+                    f"same ids cannot appear in both load_after and load_before: {contradictory!r}",
+                )
+            )
     return errors
 
 
 def validate_manifest(path: Path, edition: str) -> list[str]:
+    if edition not in ENGINE_BY_EDITION:
+        return [f"[ERROR] {path} :: <manifest> :: unsupported edition {edition!r}"]
     try:
         mods = load_mods(path)
     except ValueError as exc:
@@ -207,4 +462,201 @@ def validate_manifest(path: Path, edition: str) -> list[str]:
             errors.append(f"[ERROR] {path} :: <manifest> :: non-object entry in mods list")
             continue
         errors.extend(validate_mod(mod, path, edition))
+    errors.extend(_validate_uniqueness(mods, path))
+    errors.extend(_validate_references(mods, path))
+    return errors
+
+
+def validate_source_references(
+    mods_by_edition: Mapping[str, list[dict]],
+    manifest_paths: Mapping[str, Path],
+    candidates: list[dict],
+    source_path: Path,
+    editions: Collection[str] | None = None,
+) -> list[str]:
+    """Validate optional links between edition manifests and canonical source records."""
+    errors: list[str] = []
+    selected_editions = set(editions or mods_by_edition)
+    candidate_by_id = {
+        candidate["id"]: candidate
+        for candidate in candidates
+        if isinstance(candidate, dict) and isinstance(candidate.get("id"), str)
+    }
+    manifests_by_id: dict[str, list[tuple[str, dict]]] = defaultdict(list)
+    for edition, mods in mods_by_edition.items():
+        for mod in mods:
+            if isinstance(mod, dict) and isinstance(mod.get("id"), str):
+                manifests_by_id[mod["id"]].append((edition, mod))
+
+    for edition in selected_editions:
+        path = manifest_paths[edition]
+        for mod in mods_by_edition.get(edition, []):
+            if not isinstance(mod, dict):
+                continue
+            source_reference = mod.get("source_reference")
+            if not isinstance(source_reference, str) or not ID_RE.fullmatch(source_reference):
+                continue
+            mod_ref = _mod_ref(mod)
+            candidate = candidate_by_id.get(source_reference)
+            if candidate is None:
+                errors.append(
+                    _format_error(
+                        path,
+                        mod_ref,
+                        f"source_reference {source_reference!r} does not exist in {source_path}",
+                    )
+                )
+                continue
+
+            if mod.get("name") != candidate.get("name"):
+                errors.append(
+                    _format_error(
+                        path,
+                        mod_ref,
+                        "manifest name does not match canonical source record name "
+                        f"{candidate.get('name')!r}",
+                    )
+                )
+            intended_editions = candidate.get("intended_editions")
+            if isinstance(intended_editions, list) and edition not in intended_editions:
+                errors.append(
+                    _format_error(
+                        path,
+                        mod_ref,
+                        f"source record does not include edition {edition!r} in intended_editions",
+                    )
+                )
+            if candidate.get("candidate_status") in {"rejected", "superseded"}:
+                errors.append(
+                    _format_error(
+                        path,
+                        mod_ref,
+                        f"source_reference points to {candidate.get('candidate_status')!r} candidate",
+                    )
+                )
+            related_manifest_ids = candidate.get("related_manifest_ids")
+            if isinstance(related_manifest_ids, list) and mod.get("id") not in related_manifest_ids:
+                errors.append(
+                    _format_error(
+                        path,
+                        mod_ref,
+                        "source record related_manifest_ids does not link back to this manifest id",
+                    )
+                )
+
+            manifest_source = mod.get("source")
+            if isinstance(manifest_source, str) and not _is_placeholder(manifest_source):
+                if manifest_source != candidate.get("source_type"):
+                    errors.append(
+                        _format_error(
+                            path,
+                            mod_ref,
+                            f"manifest source {manifest_source!r} does not match canonical "
+                            f"source_type {candidate.get('source_type')!r}",
+                        )
+                    )
+            manifest_url = mod.get("url")
+            if isinstance(manifest_url, str) and not _is_placeholder(manifest_url):
+                if manifest_url != candidate.get("source_url"):
+                    errors.append(
+                        _format_error(
+                            path,
+                            mod_ref,
+                            "manifest url does not match canonical source_url",
+                        )
+                    )
+
+            status = mod.get("status")
+            if status in VERIFIED_MANIFEST_STATUSES:
+                if candidate.get("source_confidence") != "verified":
+                    errors.append(
+                        _format_error(
+                            path,
+                            mod_ref,
+                            f"status {status!r} requires source_confidence 'verified'",
+                        )
+                    )
+                if status == "accepted":
+                    if candidate.get("candidate_status") != "promoted":
+                        errors.append(
+                            _format_error(
+                                path,
+                                mod_ref,
+                                "status 'accepted' requires source candidate_status 'promoted'",
+                            )
+                        )
+                    if candidate.get("promotion_target") not in {edition, "both"}:
+                        errors.append(
+                            _format_error(
+                                path,
+                                mod_ref,
+                                "status 'accepted' requires source promotion_target to include "
+                                f"edition {edition!r}",
+                            )
+                        )
+                    compatible_statuses = {
+                        "openmw": {"openmw-compatible", "both-compatible"},
+                        "mwse": {"mwse-compatible", "both-compatible"},
+                    }
+                    if candidate.get("compatibility_status") not in compatible_statuses[edition]:
+                        errors.append(
+                            _format_error(
+                                path,
+                                mod_ref,
+                                f"status 'accepted' lacks compatible evidence for edition {edition!r}",
+                            )
+                        )
+
+    for candidate in candidates:
+        if not isinstance(candidate, dict):
+            continue
+        candidate_id = candidate.get("id")
+        related_ids = candidate.get("related_manifest_ids")
+        if not isinstance(candidate_id, str) or not isinstance(related_ids, list):
+            continue
+        for manifest_id in related_ids:
+            if not isinstance(manifest_id, str) or not ID_RE.fullmatch(manifest_id):
+                continue
+            matches = manifests_by_id.get(manifest_id, [])
+            if not matches:
+                errors.append(
+                    _format_error(
+                        source_path,
+                        candidate_id,
+                        f"related_manifest_ids references nonexistent manifest id {manifest_id!r}",
+                    )
+                )
+                continue
+            selected_matches = [
+                (edition, mod) for edition, mod in matches if edition in selected_editions
+            ]
+            if not selected_matches:
+                continue
+            intended_editions = candidate.get("intended_editions")
+            eligible_matches = [
+                (edition, mod)
+                for edition, mod in selected_matches
+                if not isinstance(intended_editions, list) or edition in intended_editions
+            ]
+            if not eligible_matches:
+                found_editions = sorted({edition for edition, _ in selected_matches})
+                errors.append(
+                    _format_error(
+                        source_path,
+                        candidate_id,
+                        f"related manifest id {manifest_id!r} resolves only to unintended "
+                        f"editions {found_editions!r}",
+                    )
+                )
+                continue
+            for edition, mod in eligible_matches:
+                if mod.get("source_reference") != candidate_id:
+                    errors.append(
+                        _format_error(
+                            source_path,
+                            candidate_id,
+                            f"manifest {edition!r} id {manifest_id!r} does not link back with "
+                            f"source_reference {candidate_id!r}",
+                        )
+                    )
     return errors

--- a/ash-archive/tools/lint_repo.py
+++ b/ash-archive/tools/lint_repo.py
@@ -5,6 +5,7 @@ import subprocess
 import sys
 import tomllib
 from pathlib import Path
+from urllib.parse import unquote, urlparse
 
 import yaml
 from yamllint import linter as yaml_linter
@@ -16,6 +17,15 @@ PRESET_ROOT = REPO_ROOT / ".agents" / "presets"
 SKILL_ROOT = REPO_ROOT / ".agents" / "skills"
 AGENT_ROOT = REPO_ROOT / ".codex" / "agents"
 SKILL_NAME_PATTERN = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
+MARKDOWN_LINK_PATTERN = re.compile(r"\[[^\]]+\]\((<[^>]+>|[^)\s]+)")
+IGNORED_DIRECTORY_NAMES = {
+    ".git",
+    ".pytest_cache",
+    ".venv",
+    "__pycache__",
+    "build",
+    "dist",
+}
 
 SKILL_PRESETS = {
     "ash-archive-triage-sources": "source-triage-agent.yaml",
@@ -31,6 +41,15 @@ SKILL_PRESETS = {
 
 def _relative(path: Path) -> str:
     return path.relative_to(REPO_ROOT).as_posix()
+
+
+def _is_ignored_repo_path(path: Path) -> bool:
+    return any(
+        part in IGNORED_DIRECTORY_NAMES
+        or part.startswith(".codex-pytest-")
+        or part.endswith(".egg-info")
+        for part in path.parts
+    )
 
 
 def _load_skill(path: Path) -> tuple[dict, str]:
@@ -50,23 +69,68 @@ def _load_skill(path: Path) -> tuple[dict, str]:
     return metadata, "\n".join(lines[closing_index + 1 :])
 
 
+def _conflict_marker_issues(path: Path, repo_root: Path = REPO_ROOT) -> list[str]:
+    issues: list[str] = []
+    for line_number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+        if line.startswith("<<<<<<< ") or line == "=======" or line.startswith(">>>>>>> "):
+            issues.append(
+                f"{path.relative_to(repo_root).as_posix()}:{line_number}: unresolved merge marker"
+            )
+    return issues
+
+
 def _find_conflict_markers() -> list[str]:
-    patterns = ("*.md", "*.py", "*.toml", "*.yaml", "*.yml", "*.control.meta")
+    patterns = ("*.md", "*.txt", "*.py", "*.toml", "*.yaml", "*.yml", "*.control.meta")
     paths = {path for pattern in patterns for path in REPO_ROOT.rglob(pattern)}
+    license_path = REPO_ROOT / "LICENSE"
+    if license_path.exists():
+        paths.add(license_path)
     issues: list[str] = []
 
     for path in sorted(paths):
-        if any(part in {".git", ".pytest_cache", "__pycache__"} for part in path.parts):
+        if _is_ignored_repo_path(path):
             continue
-        for line_number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
-            if line.startswith("<<<<<<< ") or line == "=======" or line.startswith(">>>>>>> "):
-                issues.append(f"{_relative(path)}:{line_number}: unresolved merge marker")
+        issues.extend(_conflict_marker_issues(path))
 
     return issues
 
 
+def _markdown_link_issues(path: Path, repo_root: Path = REPO_ROOT) -> list[str]:
+    issues: list[str] = []
+    text = path.read_text(encoding="utf-8")
+    for line_number, line in enumerate(text.splitlines(), 1):
+        for match in MARKDOWN_LINK_PATTERN.finditer(line):
+            target = unquote(match.group(1).strip("<>"))
+            parsed = urlparse(target)
+            if parsed.scheme or target.startswith("#"):
+                continue
+
+            relative_target = target.split("#", 1)[0].split("?", 1)[0]
+            if not relative_target:
+                continue
+            if relative_target.startswith("/"):
+                resolved = repo_root / relative_target.lstrip("/")
+            else:
+                resolved = path.parent / relative_target
+            if not resolved.exists():
+                issues.append(
+                    f"{path.relative_to(repo_root).as_posix()}:{line_number}: "
+                    f"broken internal link {target!r}"
+                )
+    return issues
+
+
+def _validate_markdown_links() -> list[str]:
+    issues: list[str] = []
+    for path in sorted(REPO_ROOT.rglob("*.md")):
+        if _is_ignored_repo_path(path):
+            continue
+        issues.extend(_markdown_link_issues(path))
+    return issues
+
+
 def validate_repo_configuration() -> list[str]:
-    issues = _find_conflict_markers()
+    issues = [*_find_conflict_markers(), *_validate_markdown_links()]
 
     pyproject_path = PROJECT_ROOT / "pyproject.toml"
     try:
@@ -162,7 +226,7 @@ def lint_yaml() -> list[str]:
     issues: list[str] = []
 
     for path in sorted(yaml_paths):
-        if any(part in {".git", ".pytest_cache", "__pycache__"} for part in path.parts):
+        if _is_ignored_repo_path(path):
             continue
         text = path.read_text(encoding="utf-8")
         for problem in yaml_linter.run(text, config, filepath=_relative(path)):

--- a/ash-archive/tools/validate_manifests.py
+++ b/ash-archive/tools/validate_manifests.py
@@ -3,24 +3,62 @@ from __future__ import annotations
 
 import argparse
 import sys
+from pathlib import Path
 
-from lib.paths import EDITIONS, manifest_path
-from lib.validation import validate_manifest
+from lib.manifest import load_mods
+from lib.paths import EDITIONS, ROOT, manifest_path
+from lib.sourced_mods import validate_sourced_mods
+from lib.validation import validate_manifest, validate_source_references
+
+SOURCED_MODS_PATH = ROOT / "shared" / "sourced-mods.control.meta"
 
 
 def parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description="Validate Ash Archive edition manifests.")
+    parser = argparse.ArgumentParser(
+        description="Validate Ash Archive edition manifests and canonical source links."
+    )
     parser.add_argument("--edition", choices=EDITIONS, help="Validate one edition only.")
     return parser.parse_args()
+
+
+def validate_repository(editions: list[str], source_path: Path = SOURCED_MODS_PATH) -> list[str]:
+    errors: list[str] = []
+    manifest_paths = {edition: manifest_path(edition) for edition in EDITIONS}
+    mods_by_edition: dict[str, list[dict]] = {}
+    loaded_editions: set[str] = set()
+
+    for edition, path in manifest_paths.items():
+        try:
+            mods_by_edition[edition] = load_mods(path)
+            loaded_editions.add(edition)
+        except ValueError as exc:
+            mods_by_edition[edition] = []
+            if edition in editions:
+                errors.append(f"[ERROR] {exc}")
+
+    for edition in editions:
+        # Avoid repeating a load error already captured above.
+        if edition in loaded_editions:
+            errors.extend(validate_manifest(manifest_paths[edition], edition))
+
+    candidates, source_errors = validate_sourced_mods(source_path)
+    errors.extend(source_errors)
+    errors.extend(
+        validate_source_references(
+            mods_by_edition,
+            manifest_paths,
+            candidates,
+            source_path,
+            editions,
+        )
+    )
+    return errors
 
 
 def main() -> int:
     args = parse_args()
     editions = [args.edition] if args.edition else list(EDITIONS)
-    errors: list[str] = []
-    for edition in editions:
-        path = manifest_path(edition)
-        errors.extend(validate_manifest(path, edition))
+    errors = validate_repository(editions)
 
     if errors:
         for err in errors:


### PR DESCRIPTION
## Summary

This PR completes a repository-wide hardening pass on top of the current `main` while
preserving the separate Pilgrim/OpenMW and Sleeper/MCP + MGE XE + MWSE editions.

- hardens manifests, sourced-candidate validation, cross-edition comparison, duplicate
  handling, Markdown links, conflict-marker coverage, and generated-file checks;
- connects eight existing canonical source records to matching planned edition entries with
  reversible `source_reference` / `related_manifest_ids` links;
- keeps every linked record at `candidate`, `planned`, and `needs-testing` as appropriate;
- aligns the two CI workflows with Python 3.11, pull requests and pushes to `main`, and
  read-only generation checks;
- makes all eight YAML presets canonical and verifies their TOML agents and repo skills retain
  scope, required reading, forbidden actions, checks, stop conditions, and human gates;
- reconciles root, shared, Pilgrim, Sleeper, MO2, Wabbajack, security, roadmap, follow-up, and
  contribution documentation with the repository's actual scaffold state.

## Problems corrected

- Editable installation failed because setuptools auto-discovered multiple top-level packages.
- CI and local automation did not enforce stale generated MODLIST output, broken internal
  Markdown links, cross-edition status/name drift, malformed or empty source registries,
  reverse-link integrity, or several metadata state transitions.
- `testing` placeholders and engine prerequisites implied evidence that the repository did not
  contain.
- Explicit negative evidence such as "not tested" and placeholder reviewers could satisfy
  review gates.
- Candidate rejection/supersession and edition rejection could bypass named human review or
  rationale requirements.
- Source provenance, edition planning, promotion, compatibility evidence, and acceptance were
  not clearly separated in docs and validation.
- Agent translations and skills could drift from canonical presets, including the two Wabbajack
  agents recently added on `main`.
- Edition and release documentation contained placeholders that could be read as usable install
  or support guidance.

## Architecture decision

`shared/sourced-mods.control.meta` remains the canonical candidate identity and provenance
layer. An edition manifest may optionally point to a candidate using `source_reference`, with
the candidate retaining a reverse `related_manifest_ids` link. The link records identity and
intended-edition provenance only. It does not fill unknown archive/version/plugin fields,
promote a candidate, prove compatibility, mark testing complete, or accept a mod.

Candidate status and edition status remain independent state machines. `testing` and
`accepted` require positive evidence, a named non-placeholder reviewer, and an ISO review date.
Acceptance additionally requires a verified promoted candidate whose promotion target and
compatibility evidence include the accepting edition.

## CI and automation

- `Repository checks`: lint and tests on pull requests, pushes to `main`, and manual dispatch.
- `Archive integrity`: manifest/source validation, read-only MODLIST freshness, edition drift,
  and duplicate checks on the same triggers.
- Both use Python 3.11, `actions/checkout@v6`, and `actions/setup-python@v6` with read-only
  repository permissions.
- The generator now supports `--check`, validates marker balance/order, prints a unified diff
  when stale, and never writes in check mode.

## Validation results

Run from `ash-archive/` on Windows with Python 3.12.10:

- `python -m pip install -e ".[dev]"` - passed
- `python tools/lint_repo.py` - passed
- `python tools/validate_manifests.py` - passed for OpenMW and MWSE
- `python tools/generate_modlist_markdown.py` - both files current
- `python tools/generate_modlist_markdown.py --check` - passed without writes
- `python tools/compare_editions.py` - no shared status or shared-ID name mismatches
- `python tools/check_duplicate_mods.py` - no duplicate IDs or likely accidental names
- `python tools/summarize_sourced_mods.py` - 8 candidates; none promoted or compatibility-tested
- `python -m pytest -q -p no:cacheprovider --basetemp .codex-pytest-final` - 111 passed
- `git diff --check` - passed

The bare `pytest` command is not exposed on this Windows user PATH and failed before collection;
the same installed suite passed through `python -m pytest`. CI will run the console entry point
on Ubuntu/Python 3.11.

## Deliberately not performed

- No in-game OpenMW, MCP, MGE XE, or MWSE compatibility test was claimed.
- No Wabbajack compile, clean install, MO2 profile validation, performance benchmark, or release
  packaging was attempted because the repository has no production artifacts or verified build.
- No candidate was promoted, accepted, rejected, or marked compatible.
- No missing source URL, version, archive name, Nexus ID, plugin list, or test result was invented.

## Remaining human decisions and blockers

- Resolve the root CC0 license versus the incomplete nested MIT license text.
- Establish and document a confirmed private security-reporting channel.
- Resolve remaining source identity, package, redistribution, and licensing questions in the
  triage backlog.
- Perform and record edition-specific compatibility, load-order, atmosphere, performance, and
  clean-install test routes before changing candidates from `needs-testing` or manifests from
  `planned`.
- Human approval remains required for candidate promotion/rejection, edition acceptance,
  compatibility claims, support boundaries, final load order, and release readiness.

## Commits

- `tools: harden validation and CI`
- `data: link canonical sources to edition plans`
- `agents: enforce canonical maintenance guardrails`
- `docs: reconcile project status and workflows`
