### PR TITLE
🔒 fix: path traversal vulnerability in Markdown link validation

### DIFF
--- a/ash-archive/tests/test_lint_repo.py
+++ b/ash-archive/tests/test_lint_repo.py
@@ -51,3 +51,12 @@ def test_markdown_link_check_ignores_external_and_page_anchor_links(tmp_path: Pa
     )
 
     assert _markdown_link_issues(source, tmp_path) == []
+
+
+def test_markdown_link_check_reports_out_of_bounds_link(tmp_path: Path) -> None:
+    source = tmp_path / "source.md"
+    source.write_text("[Out of Bounds](../../../../../../../etc/passwd)\n", encoding="utf-8")
+
+    assert _markdown_link_issues(source, tmp_path) == [
+        "source.md:1: link escapes repository bounds '../../../../../../../etc/passwd'"
+    ]

--- a/ash-archive/tools/lint_repo.py
+++ b/ash-archive/tools/lint_repo.py
@@ -112,7 +112,24 @@ def _markdown_link_issues(path: Path, repo_root: Path = REPO_ROOT) -> list[str]:
                 resolved = repo_root / relative_target.lstrip("/")
             else:
                 resolved = path.parent / relative_target
-            if not resolved.exists():
+
+            try:
+                resolved_absolute = resolved.resolve()
+                repo_root_absolute = repo_root.resolve()
+            except RuntimeError:
+                # Handle cases like recursive symlinks if they ever appear
+                issues.append(
+                    f"{path.relative_to(repo_root).as_posix()}:{line_number}: "
+                    f"link resolution failed for {target!r}"
+                )
+                continue
+
+            if not resolved_absolute.is_relative_to(repo_root_absolute):
+                issues.append(
+                    f"{path.relative_to(repo_root).as_posix()}:{line_number}: "
+                    f"link escapes repository bounds {target!r}"
+                )
+            elif not resolved.exists():
                 issues.append(
                     f"{path.relative_to(repo_root).as_posix()}:{line_number}: "
                     f"broken internal link {target!r}"


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed
The internal markdown link validator in `tools/lint_repo.py` used user-provided link paths (from markdown files) and directly checked for their existence on the file system after resolving them relative to the current file or repo root, without bounds checking. This allowed malicious or malformed links (e.g. `../../../../../etc/passwd`) to traverse outside the repository directory.

⚠️ **Risk:** The potential impact if left unfixed
A path traversal vulnerability would allow the linting tool to probe the host file system for the existence of arbitrary files based on external input (malicious markdown links), which could be a stepping stone for further exploitation depending on what environment the tool runs in.

🛡️ **Solution:** How the fix addresses the vulnerability
The fix adds a strict validation check before checking if the file exists:
1. It resolves both the targeted file path and the repository root path to their absolute forms (following symlinks).
2. It uses `is_relative_to()` to ensure the absolute target path falls under the absolute repository root path.
3. If it escapes bounds, it explicitly flags an issue and skips checking existence.
4. It also catches `RuntimeError` during `resolve()` in case of recursive symlink loops.
Added a test specifically verifying an out-of-bounds link is reported.

---
*PR created automatically by Jules for task [2858293342055765692](https://jules.google.com/task/2858293342055765692) started by @JasonBreen*