### PR TITLE
🧪 Add tests for render_mod_sections

### DIFF
--- a/ash-archive/tests/test_markdown.py
+++ b/ash-archive/tests/test_markdown.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import pytest
+
+from tools.lib.markdown import _sanitize_inline, render_mod_sections
+
+
+def test_sanitize_inline() -> None:
+    assert _sanitize_inline("normal text") == "normal text"
+    assert _sanitize_inline("text with `backticks`") == "text with 'backticks'"
+    assert _sanitize_inline("text\nwith\rnewlines") == "text with newlines"
+    assert _sanitize_inline("  leading and trailing  ") == "leading and trailing"
+
+
+def test_render_mod_sections_empty() -> None:
+    assert render_mod_sections([]) == "\n"
+
+
+def test_render_mod_sections_basic() -> None:
+    mods = [
+        {
+            "category": "Visuals",
+            "name": "Better Textures",
+            "id": "better-textures",
+            "status": "accepted",
+            "engine": ["openmw", "mwse"],
+            "cross_edition_status": "identical",
+            "decision_reason": "Great mod.",
+        }
+    ]
+    expected = (
+        "## Visuals\n"
+        "- **Better Textures** (`better-textures`) — status: `accepted`, engine: `openmw, mwse`, "
+        "cross-edition: `identical`. Reason: Great mod.\n"
+    )
+    assert render_mod_sections(mods) == expected
+
+
+def test_render_mod_sections_sorting() -> None:
+    mods = [
+        {
+            "category": "Visuals",
+            "name": "B Mod",
+            "id": "b-mod",
+            "status": "accepted",
+            "cross_edition_status": "identical",
+            "decision_reason": "test",
+            "priority": 2,
+        },
+        {
+            "category": "Audio",
+            "name": "A Mod",
+            "id": "a-mod",
+            "status": "accepted",
+            "cross_edition_status": "identical",
+            "decision_reason": "test",
+            "priority": 1,
+        },
+        {
+            "category": "Visuals",
+            "name": "C Mod",
+            "id": "c-mod",
+            "status": "accepted",
+            "cross_edition_status": "identical",
+            "decision_reason": "test",
+            "priority": 1,
+        },
+    ]
+
+    # Audio should be before Visuals (alphabetical).
+    # Within Visuals, C Mod (priority 1) should be before B Mod (priority 2).
+    expected = (
+        "## Audio\n"
+        "- **A Mod** (`a-mod`) — status: `accepted`, engine: ``, cross-edition: `identical`. Reason: test\n"
+        "\n"
+        "## Visuals\n"
+        "- **C Mod** (`c-mod`) — status: `accepted`, engine: ``, cross-edition: `identical`. Reason: test\n"
+        "- **B Mod** (`b-mod`) — status: `accepted`, engine: ``, cross-edition: `identical`. Reason: test\n"
+    )
+    assert render_mod_sections(mods) == expected
+
+
+def test_render_mod_sections_missing_optional_keys() -> None:
+    mods = [
+        {
+            "category": "Core",
+            "name": "Core Mod",
+            "id": "core-mod",
+            "status": "testing",
+            "cross_edition_status": "unknown",
+            "decision_reason": "pending",
+            # missing "engine" and "priority"
+        },
+        {
+            "category": "Core",
+            "name": "Another Core Mod",
+            "id": "another-core",
+            "status": "testing",
+            "cross_edition_status": "unknown",
+            "decision_reason": "pending",
+            "priority": 1,
+            # missing "engine"
+        }
+    ]
+    # Another Core Mod (priority 1) should be before Core Mod (missing priority = 9999).
+    expected = (
+        "## Core\n"
+        "- **Another Core Mod** (`another-core`) — status: `testing`, engine: ``, cross-edition: `unknown`. Reason: pending\n"
+        "- **Core Mod** (`core-mod`) — status: `testing`, engine: ``, cross-edition: `unknown`. Reason: pending\n"
+    )
+    assert render_mod_sections(mods) == expected
+
+
+def test_render_mod_sections_sanitization() -> None:
+    mods = [
+        {
+            "category": "Bad\nCategory",
+            "name": "Name\nWith\nNewlines",
+            "id": "id`with`backticks",
+            "status": "accepted\nstatus",
+            "engine": ["bad\nengine", "good`engine"],
+            "cross_edition_status": "cross\nedition",
+            "decision_reason": "Reason\nwith\n`backticks`",
+        }
+    ]
+    expected = (
+        "## Bad Category\n"
+        "- **Name With Newlines** (`id'with'backticks`) — status: `accepted status`, engine: `bad engine, good'engine`, "
+        "cross-edition: `cross edition`. Reason: Reason with 'backticks'\n"
+    )
+    assert render_mod_sections(mods) == expected

--- a/ash-archive/tests/test_markdown.py
+++ b/ash-archive/tests/test_markdown.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import pytest
-
 from tools.lib.markdown import _sanitize_inline, render_mod_sections
 
 
@@ -100,7 +98,7 @@ def test_render_mod_sections_missing_optional_keys() -> None:
             "decision_reason": "pending",
             "priority": 1,
             # missing "engine"
-        }
+        },
     ]
     # Another Core Mod (priority 1) should be before Core Mod (missing priority = 9999).
     expected = (


### PR DESCRIPTION
🎯 **What:** The testing gap in `ash-archive/tools/lib/markdown.py` for the previously untested `render_mod_sections` public function has been addressed by adding a dedicated pytest test suite.

📊 **Coverage:** The new test suite covers:
- Empty inputs.
- Happy path single mod formatting.
- Complex sorting logic across categories and mod priorities (including missing priority fallback behavior).
- Missing optional keys (like missing engine or priority fields).
- Input sanitization logic preventing markdown injection via malformed text with newlines or backticks.

✨ **Result:** Increased test reliability and confidence when refactoring the markdown rendering functionality.

---
*PR created automatically by Jules for task [17051325441814003779](https://jules.google.com/task/17051325441814003779) started by @JasonBreen*