### PR TITLE
🧹 Refactor validate_source_references to improve maintainability

### DIFF
--- a/ash-archive/tools/lib/validation.py
+++ b/ash-archive/tools/lib/validation.py
@@ -467,27 +467,14 @@ def validate_manifest(path: Path, edition: str) -> list[str]:
     return errors
 
 
-def validate_source_references(
+def _check_manifest_to_source(
     mods_by_edition: Mapping[str, list[dict]],
     manifest_paths: Mapping[str, Path],
-    candidates: list[dict],
+    candidate_by_id: dict[str, dict],
     source_path: Path,
-    editions: Collection[str] | None = None,
+    selected_editions: set[str],
 ) -> list[str]:
-    """Validate optional links between edition manifests and canonical source records."""
     errors: list[str] = []
-    selected_editions = set(editions or mods_by_edition)
-    candidate_by_id = {
-        candidate["id"]: candidate
-        for candidate in candidates
-        if isinstance(candidate, dict) and isinstance(candidate.get("id"), str)
-    }
-    manifests_by_id: dict[str, list[tuple[str, dict]]] = defaultdict(list)
-    for edition, mods in mods_by_edition.items():
-        for mod in mods:
-            if isinstance(mod, dict) and isinstance(mod.get("id"), str):
-                manifests_by_id[mod["id"]].append((edition, mod))
-
     for edition in selected_editions:
         path = manifest_paths[edition]
         for mod in mods_by_edition.get(edition, []):
@@ -606,7 +593,16 @@ def validate_source_references(
                                 f"status 'accepted' lacks compatible evidence for edition {edition!r}",
                             )
                         )
+    return errors
 
+
+def _check_source_to_manifest(
+    candidates: list[dict],
+    manifests_by_id: dict[str, list[tuple[str, dict]]],
+    source_path: Path,
+    selected_editions: set[str],
+) -> list[str]:
+    errors: list[str] = []
     for candidate in candidates:
         if not isinstance(candidate, dict):
             continue
@@ -659,4 +655,36 @@ def validate_source_references(
                             f"source_reference {candidate_id!r}",
                         )
                     )
+    return errors
+
+
+def validate_source_references(
+    mods_by_edition: Mapping[str, list[dict]],
+    manifest_paths: Mapping[str, Path],
+    candidates: list[dict],
+    source_path: Path,
+    editions: Collection[str] | None = None,
+) -> list[str]:
+    """Validate optional links between edition manifests and canonical source records."""
+    selected_editions = set(editions or mods_by_edition)
+    candidate_by_id = {
+        candidate["id"]: candidate
+        for candidate in candidates
+        if isinstance(candidate, dict) and isinstance(candidate.get("id"), str)
+    }
+    manifests_by_id: dict[str, list[tuple[str, dict]]] = defaultdict(list)
+    for edition, mods in mods_by_edition.items():
+        for mod in mods:
+            if isinstance(mod, dict) and isinstance(mod.get("id"), str):
+                manifests_by_id[mod["id"]].append((edition, mod))
+
+    errors: list[str] = []
+    errors.extend(
+        _check_manifest_to_source(
+            mods_by_edition, manifest_paths, candidate_by_id, source_path, selected_editions
+        )
+    )
+    errors.extend(
+        _check_source_to_manifest(candidates, manifests_by_id, source_path, selected_editions)
+    )
     return errors


### PR DESCRIPTION
🎯 **What:** The massive monolithic function `validate_source_references` in `ash-archive/tools/lib/validation.py` has been split into two helper functions (`_check_manifest_to_source` and `_check_source_to_manifest`).

💡 **Why:** Splitting this function cuts its complexity in half, greatly improving the maintainability and readability of the codebase.

✅ **Verification:**
- Ran the `ruff` formatter to ensure codebase formatting standard compliance.
- Ran `pytest` to verify the full test suite still passes without errors.
- Checked pre-commit validations and code review to verify code behavior remains completely intact.

✨ **Result:** The code health issue is fully addressed without changing original functionality.

---
*PR created automatically by Jules for task [2517480938229010965](https://jules.google.com/task/2517480938229010965) started by @JasonBreen*