### PR TITLE
🧪 Add tests for lib/paths.py

### DIFF
--- a/ash-archive/tests/test_paths.py
+++ b/ash-archive/tests/test_paths.py
@@ -1,0 +1,17 @@
+from tools.lib.paths import ROOT, categories_path, manifest_path
+
+
+def test_manifest_path():
+    openmw_path = manifest_path("openmw")
+    assert openmw_path == ROOT / "editions" / "openmw" / "manifests" / "mods.control.meta"
+    assert openmw_path.parts[-4:] == ("editions", "openmw", "manifests", "mods.control.meta")
+
+    mwse_path = manifest_path("mwse")
+    assert mwse_path == ROOT / "editions" / "mwse" / "manifests" / "mods.control.meta"
+    assert mwse_path.parts[-4:] == ("editions", "mwse", "manifests", "mods.control.meta")
+
+
+def test_categories_path():
+    cat_path = categories_path()
+    assert cat_path == ROOT / "shared" / "categories.control.meta"
+    assert cat_path.parts[-2:] == ("shared", "categories.control.meta")

--- a/ash-archive/tests/test_paths.py
+++ b/ash-archive/tests/test_paths.py
@@ -1,17 +1,21 @@
-from tools.lib.paths import ROOT, categories_path, manifest_path
+from pathlib import Path
+
+from tools.lib.paths import categories_path, manifest_path
+
+_ROOT = Path(__file__).resolve().parents[1]
 
 
-def test_manifest_path():
+def test_manifest_path() -> None:
     openmw_path = manifest_path("openmw")
-    assert openmw_path == ROOT / "editions" / "openmw" / "manifests" / "mods.control.meta"
+    assert openmw_path == _ROOT / "editions" / "openmw" / "manifests" / "mods.control.meta"
     assert openmw_path.parts[-4:] == ("editions", "openmw", "manifests", "mods.control.meta")
 
     mwse_path = manifest_path("mwse")
-    assert mwse_path == ROOT / "editions" / "mwse" / "manifests" / "mods.control.meta"
+    assert mwse_path == _ROOT / "editions" / "mwse" / "manifests" / "mods.control.meta"
     assert mwse_path.parts[-4:] == ("editions", "mwse", "manifests", "mods.control.meta")
 
 
-def test_categories_path():
+def test_categories_path() -> None:
     cat_path = categories_path()
-    assert cat_path == ROOT / "shared" / "categories.control.meta"
+    assert cat_path == _ROOT / "shared" / "categories.control.meta"
     assert cat_path.parts[-2:] == ("shared", "categories.control.meta")


### PR DESCRIPTION
🎯 **What:** Missing test file for lib/paths.py has been created.
📊 **Coverage:** The path creation functions `manifest_path(edition)` and `categories_path()` are now tested to ensure they construct correct `Path` objects matching expected folder structures for different editions and shared resources.
✨ **Result:** Test suite coverage has been improved with no side effects or regressions.

---
*PR created automatically by Jules for task [1908772539924998087](https://jules.google.com/task/1908772539924998087) started by @JasonBreen*