### PR TITLE
🧹 [code health improvement] Refactor `_validate_candidate_consistency` function into specific validators

### DIFF
--- a/ash-archive/tools/lib/sourced_mods.py
+++ b/ash-archive/tools/lib/sourced_mods.py
@@ -180,7 +180,7 @@ def _validate_lists(candidate: dict, path: Path, mod_ref: str) -> list[str]:
     return errors
 
 
-def _validate_candidate_consistency(candidate: dict, path: Path, mod_ref: str) -> list[str]:
+def _validate_source_url_consistency(candidate: dict, path: Path, mod_ref: str) -> list[str]:
     errors: list[str] = []
     source_url = candidate["source_url"]
     if isinstance(source_url, str) and source_url.strip() and not _is_valid_url(source_url):
@@ -189,8 +189,13 @@ def _validate_candidate_consistency(candidate: dict, path: Path, mod_ref: str) -
                 path, mod_ref, f"malformed source_url {source_url!r}; expected http(s) URL"
             )
         )
+    return errors
 
+
+def _validate_source_confidence_consistency(candidate: dict, path: Path, mod_ref: str) -> list[str]:
+    errors: list[str] = []
     source_confidence = candidate["source_confidence"]
+    source_url = candidate["source_url"]
     if source_confidence == "verified":
         if (
             not isinstance(source_url, str)
@@ -212,7 +217,13 @@ def _validate_candidate_consistency(candidate: dict, path: Path, mod_ref: str) -
             errors.append(
                 _format_error(path, mod_ref, "source_confidence 'verified' requires evidence_notes")
             )
+    return errors
 
+
+def _validate_compatibility_status_consistency(
+    candidate: dict, path: Path, mod_ref: str
+) -> list[str]:
+    errors: list[str] = []
     compatibility_status = candidate["compatibility_status"]
     if compatibility_status in EVIDENCED_COMPATIBILITY_STATUS:
         if _is_placeholder(candidate["evidence_notes"]) or _is_placeholder(
@@ -250,7 +261,13 @@ def _validate_candidate_consistency(candidate: dict, path: Path, mod_ref: str) -
                     f"compatibility_status {compatibility_status!r} contradicts intended_editions",
                 )
             )
+    return errors
 
+
+def _validate_promotion_target_consistency(candidate: dict, path: Path, mod_ref: str) -> list[str]:
+    errors: list[str] = []
+    intended_editions = candidate["intended_editions"]
+    if isinstance(intended_editions, list):
         promotion_target = candidate["promotion_target"]
         required_target_editions = {
             "openmw": {"openmw"},
@@ -265,7 +282,11 @@ def _validate_candidate_consistency(candidate: dict, path: Path, mod_ref: str) -
                     f"promotion_target {promotion_target!r} contradicts intended_editions",
                 )
             )
+    return errors
 
+
+def _validate_candidate_status_consistency(candidate: dict, path: Path, mod_ref: str) -> list[str]:
+    errors: list[str] = []
     candidate_status = candidate["candidate_status"]
     if candidate_status == "promoted":
         if candidate["promotion_target"] in {"neither", "undecided"}:
@@ -310,6 +331,16 @@ def _validate_candidate_consistency(candidate: dict, path: Path, mod_ref: str) -
                     f"candidate_status {candidate_status!r} requires review information",
                 )
             )
+    return errors
+
+
+def _validate_candidate_consistency(candidate: dict, path: Path, mod_ref: str) -> list[str]:
+    errors: list[str] = []
+    errors.extend(_validate_source_url_consistency(candidate, path, mod_ref))
+    errors.extend(_validate_source_confidence_consistency(candidate, path, mod_ref))
+    errors.extend(_validate_compatibility_status_consistency(candidate, path, mod_ref))
+    errors.extend(_validate_promotion_target_consistency(candidate, path, mod_ref))
+    errors.extend(_validate_candidate_status_consistency(candidate, path, mod_ref))
     return errors
 
 


### PR DESCRIPTION
🎯 **What:** The `_validate_candidate_consistency` god function in `ash-archive/tools/lib/sourced_mods.py` was refactored by breaking it down into smaller, self-contained, specifically-scoped validators.

💡 **Why:** Grouping several unrelated consistency checks in a single function increases complexity, hinders code readability, and makes unit testing difficult. Separating them into specific functions improves the code's maintainability.

✅ **Verification:** The file was auto-formatted with `ruff` and tested with `pytest`. It successfully passed all functionality tests, confirming no functionality was broken.

✨ **Result:** The `_validate_candidate_consistency` function now serves as a clean dispatcher that aggregates the consistency check results from distinct and more manageable sub-functions.

---
*PR created automatically by Jules for task [3711207167324530051](https://jules.google.com/task/3711207167324530051) started by @JasonBreen*