### PR TITLE
Sync preset docs and add tooling docstrings

### DIFF
--- a/ash-archive/LOCAL-AGENT-PRESETS.md
+++ b/ash-archive/LOCAL-AGENT-PRESETS.md
@@ -218,48 +218,6 @@ Use this preset only for pre-release evidence gathering and checklist preparatio
 - List blockers by severity.
 - Include exact validation commands and results.
 
-### `wabbajack-list-planner`
-
-Use this preset for nonbinding, evidence-backed planning across the Pilgrim and Sleeper lists.
-
-**Inputs**
-- The project bible, roadmap, follow-up tasks, and shared sourcing records.
-- Both edition manifests, README files, and Wabbajack planning documents.
-
-**Allowed actions**
-- Analyze category coverage and propose evaluation batches.
-- Recommend edition-specific direction while preserving engine-specific differences.
-- Identify sourcing, compatibility, and decision gaps without promoting candidates.
-
-**Stop conditions**
-- Candidate fit depends on unrecorded provenance or compatibility evidence.
-- Edition placement, final load order, or a design preference requires human judgment.
-
-**Completion report**
-- Separate recorded facts, interpretations, recommendations, and evidence gaps.
-- Report Pilgrim and Sleeper plans independently, with exact checks and skipped-check reasons.
-
-### `wabbajack-list-writer`
-
-Use this preset to draft Wabbajack, installation, known-issue, and release prose from recorded evidence.
-
-**Inputs**
-- Root and edition README files, changelogs, and Wabbajack documents.
-- Edition installation, post-install, and known-issues documentation.
-
-**Allowed actions**
-- Draft edition descriptions, verified feature copy, installer guidance, and release notes.
-- Preserve distinct Pilgrim and Sleeper voices while keeping instructions and warnings plain.
-- Label unsupported language as a draft gap instead of presenting it as fact.
-
-**Stop conditions**
-- A material claim lacks repository evidence or would imply unsupported readiness.
-- Final public voice, support boundaries, or project direction require human judgment.
-
-**Completion report**
-- Identify the repository source for material claims and flag claims needing review.
-- Distinguish edition-specific copy and report exact checks and skipped-check reasons.
-
 ## Recommended local preset format
 
 Local agent runners can encode each preset as YAML, JSON, or TOML. Keep the structure simple and auditable:
@@ -298,8 +256,6 @@ The repository currently includes runner-neutral YAML presets under `.agents/pre
 - `.agents/presets/wabbajack-list-planner.yaml`
 - `.agents/presets/wabbajack-list-writer.yaml`
 - `.agents/presets/release-readiness-agent.yaml`
-- `.agents/presets/wabbajack-list-planner.yaml`
-- `.agents/presets/wabbajack-list-writer.yaml`
 
 Use `.agents/presets/README.md` as the local index for maintenance presets and this document as the policy source for guardrails and review gates.
 
@@ -329,8 +285,6 @@ Reusable workflows live under `.agents/skills/` and are available throughout the
 | `ash-archive-plan-wabbajack-list` | `wabbajack-list-planner.yaml` |
 | `ash-archive-write-wabbajack-copy` | `wabbajack-list-writer.yaml` |
 | `ash-archive-assess-release` | `release-readiness-agent.yaml` |
-| `ash-archive-plan-wabbajack-list` | `wabbajack-list-planner.yaml` |
-| `ash-archive-write-wabbajack-copy` | `wabbajack-list-writer.yaml` |
 
 Each skill contains concise procedural guidance and generated UI metadata. The preset remains
 the policy source; a skill cannot relax its stop conditions or human review gates.

--- a/ash-archive/tools/check_duplicate_mods.py
+++ b/ash-archive/tools/check_duplicate_mods.py
@@ -16,6 +16,7 @@ class DuplicateReport:
 
 
 def find_duplicates(mods: list[dict]) -> DuplicateReport:
+    """Find duplicate IDs and same-name/different-ID collisions in one manifest."""
     id_counts = defaultdict(int)
     name_to_ids = defaultdict(set)
     for mod in mods:
@@ -34,6 +35,7 @@ def find_duplicates(mods: list[dict]) -> DuplicateReport:
 def find_cross_edition_name_mismatches(
     mods_by_edition: dict[str, list[dict]],
 ) -> list[tuple[str, str, str]]:
+    """Find same-name mods that map to different IDs across editions."""
     name_to_edition_ids: dict[str, dict[str, set[str]]] = defaultdict(lambda: defaultdict(set))
     for edition, mods in mods_by_edition.items():
         for mod in mods:
@@ -65,6 +67,7 @@ def _load_mods_for_path(path: Path) -> tuple[list[dict], bool]:
 
 
 def main() -> int:
+    """CLI entry point."""
     has_errors = False
     has_duplicate_names = False
     mods_by_edition: dict[str, list[dict]] = {}

--- a/ash-archive/tools/compare_editions.py
+++ b/ash-archive/tools/compare_editions.py
@@ -7,6 +7,7 @@ from lib.validation import validate_manifest
 
 
 def find_cross_status_mismatches(openmw: dict[str, dict], mwse: dict[str, dict]) -> list[str]:
+    """Return shared manifest IDs with differing `cross_edition_status` values."""
     shared = set(openmw) & set(mwse)
     return sorted(
         mod_id
@@ -16,6 +17,7 @@ def find_cross_status_mismatches(openmw: dict[str, dict], mwse: dict[str, dict])
 
 
 def find_cross_name_mismatches(openmw: dict[str, dict], mwse: dict[str, dict]) -> list[str]:
+    """Return shared manifest IDs whose `name` differs across editions."""
     shared = set(openmw) & set(mwse)
     return sorted(
         mod_id for mod_id in shared if openmw[mod_id].get("name") != mwse[mod_id].get("name")
@@ -23,6 +25,7 @@ def find_cross_name_mismatches(openmw: dict[str, dict], mwse: dict[str, dict]) -
 
 
 def main() -> int:
+    """CLI entry point."""
     errs = []
     openmw_mods: list[dict] | None = None
     try:

--- a/ash-archive/tools/generate_modlist_markdown.py
+++ b/ash-archive/tools/generate_modlist_markdown.py
@@ -14,6 +14,7 @@ END = "<!-- GENERATED-CONTENT:END -->"
 
 
 def render_modlist_document(text: str, content: str) -> str:
+    """Insert or replace the generated MODLIST section bounded by marker comments."""
     start_count = text.count(START)
     end_count = text.count(END)
     if start_count != end_count or start_count > 1:
@@ -32,11 +33,13 @@ def render_modlist_document(text: str, content: str) -> str:
 
 
 def expected_modlist(path: Path, content: str) -> tuple[str, str]:
+    """Return `(current_text, expected_text)` for a MODLIST file."""
     current = path.read_text(encoding="utf-8") if path.exists() else "# Modlist\n\n"
     return current, render_modlist_document(current, content)
 
 
 def report_diff(path: Path, current: str, expected: str) -> None:
+    """Print a unified diff between committed and generated MODLIST content."""
     diff = difflib.unified_diff(
         current.splitlines(keepends=True),
         expected.splitlines(keepends=True),
@@ -47,6 +50,7 @@ def report_diff(path: Path, current: str, expected: str) -> None:
 
 
 def main() -> int:
+    """CLI entry point."""
     parser = argparse.ArgumentParser(description="Generate MODLIST markdown from manifests.")
     parser.add_argument("--edition", choices=EDITIONS)
     parser.add_argument(

--- a/ash-archive/tools/lib/manifest.py
+++ b/ash-archive/tools/lib/manifest.py
@@ -6,6 +6,7 @@ import yaml
 
 
 def load_meta_document(path: Path) -> dict:
+    """Load a YAML metadata document and enforce a mapping root."""
     try:
         with path.open("r", encoding="utf-8") as handle:
             data = yaml.safe_load(handle) or {}
@@ -20,6 +21,7 @@ def load_meta_document(path: Path) -> dict:
 
 
 def load_mods(path: Path) -> list[dict]:
+    """Return the `mods` list from a metadata document."""
     data = load_meta_document(path)
     mods = data.get("mods", [])
     if not isinstance(mods, list):

--- a/ash-archive/tools/lib/markdown.py
+++ b/ash-archive/tools/lib/markdown.py
@@ -8,6 +8,7 @@ def _sanitize_inline(value: str) -> str:
 
 
 def render_mod_sections(mods: list[dict]) -> str:
+    """Render manifest entries as grouped Markdown sections for MODLIST output."""
     grouped: dict[str, list[dict]] = defaultdict(list)
     for mod in mods:
         grouped[mod["category"]].append(mod)

--- a/ash-archive/tools/lib/paths.py
+++ b/ash-archive/tools/lib/paths.py
@@ -5,8 +5,10 @@ EDITIONS = ("openmw", "mwse")
 
 
 def manifest_path(edition: str) -> Path:
+    """Return the manifest file path for an edition key."""
     return ROOT / "editions" / edition / "manifests" / "mods.control.meta"
 
 
 def categories_path() -> Path:
+    """Return the shared category metadata file path."""
     return ROOT / "shared" / "categories.control.meta"

--- a/ash-archive/tools/lib/sourced_mods.py
+++ b/ash-archive/tools/lib/sourced_mods.py
@@ -345,6 +345,7 @@ def _validate_candidate_consistency(candidate: dict, path: Path, mod_ref: str) -
 
 
 def validate_candidate(candidate: dict, path: Path) -> list[str]:
+    """Validate one sourced-candidate record against schema and consistency rules."""
     errors: list[str] = []
     mod_ref = _mod_ref(candidate)
 
@@ -385,6 +386,7 @@ def validate_candidate(candidate: dict, path: Path) -> list[str]:
 
 
 def load_sourced_candidates(path: Path) -> list[dict]:
+    """Load the canonical `sourced_candidates` list from metadata."""
     data = load_meta_document(path)
     candidates = data.get("sourced_candidates")
     if not isinstance(candidates, list):
@@ -393,6 +395,7 @@ def load_sourced_candidates(path: Path) -> list[dict]:
 
 
 def validate_sourced_mods(path: Path) -> tuple[list[dict], list[str]]:
+    """Load sourced candidates and return `(candidates, validation_errors)`."""
     try:
         candidates = load_sourced_candidates(path)
     except ValueError as exc:

--- a/ash-archive/tools/lib/validation.py
+++ b/ash-archive/tools/lib/validation.py
@@ -328,6 +328,7 @@ def _validate_review_metadata(mod: dict, path: Path, mod_ref: str) -> list[str]:
 
 
 def validate_mod(mod: dict, path: Path, expected_edition: str) -> list[str]:
+    """Validate one manifest entry against schema, evidence, and review rules."""
     errors: list[str] = []
     mod_ref = _mod_ref(mod)
     for field_name in REQ_FIELDS:
@@ -448,6 +449,7 @@ def _validate_references(mods: list[dict], path: Path) -> list[str]:
 
 
 def validate_manifest(path: Path, edition: str, mods: list[dict] | None = None) -> list[str]:
+    """Validate a full edition manifest and return collected error strings."""
     if edition not in ENGINE_BY_EDITION:
         return [f"[ERROR] {path} :: <manifest> :: unsupported edition {edition!r}"]
     if mods is None:
@@ -556,6 +558,7 @@ def _check_manifest_to_source(
 
             status = mod.get("status")
             if status in VERIFIED_MANIFEST_STATUSES:
+                # Verified manifest statuses must trace to a verified, consistent source candidate.
                 if candidate.get("source_confidence") != "verified":
                     errors.append(
                         _format_error(
@@ -630,6 +633,8 @@ def _check_source_to_manifest(
             if not selected_matches:
                 continue
             intended_editions = candidate.get("intended_editions")
+            # A related manifest ID is only valid when at least one selected edition match is
+            # also intended by the candidate record.
             eligible_matches = [
                 (edition, mod)
                 for edition, mod in selected_matches
@@ -668,6 +673,7 @@ def validate_source_references(
 ) -> list[str]:
     """Validate optional links between edition manifests and canonical source records."""
     selected_editions = set(editions or mods_by_edition)
+    # Build quick lookup indexes once so we can enforce both forward and reverse link integrity.
     candidate_by_id = {
         candidate["id"]: candidate
         for candidate in candidates

--- a/ash-archive/tools/lint_repo.py
+++ b/ash-archive/tools/lint_repo.py
@@ -242,6 +242,7 @@ def _validate_skills() -> list[str]:
 
 
 def validate_repo_configuration() -> list[str]:
+    """Run repository policy checks that do not require external linters."""
     return [
         *_find_conflict_markers(),
         *_validate_markdown_links(),
@@ -252,6 +253,7 @@ def validate_repo_configuration() -> list[str]:
 
 
 def lint_yaml() -> list[str]:
+    """Lint YAML, YML, and control-metadata files with the repository config."""
     config = YamlLintConfig((REPO_ROOT / ".yamllint.yml").read_text(encoding="utf-8"))
     yaml_paths = {
         *REPO_ROOT.rglob("*.yaml"),
@@ -277,6 +279,7 @@ def _run_ruff(arguments: list[str]) -> int:
 
 
 def main() -> int:
+    """CLI entry point."""
     issues = [*validate_repo_configuration(), *lint_yaml()]
     for issue in issues:
         print(f"[ERROR] {issue}")

--- a/ash-archive/tools/summarize_sourced_mods.py
+++ b/ash-archive/tools/summarize_sourced_mods.py
@@ -31,6 +31,7 @@ def _parse_args() -> argparse.Namespace:
 
 
 def generate_summary(candidates: list[dict]) -> str:
+    """Build a bucketed Markdown table summary for sourced candidates."""
     lines = []
     grouped: dict[str, list[dict]] = defaultdict(list)
     for candidate in candidates:
@@ -63,6 +64,7 @@ def generate_summary(candidates: list[dict]) -> str:
 
 
 def main() -> int:
+    """CLI entry point."""
     args = _parse_args()
     candidates, errors = validate_sourced_mods(args.file)
 

--- a/ash-archive/tools/validate_manifests.py
+++ b/ash-archive/tools/validate_manifests.py
@@ -14,6 +14,7 @@ SOURCED_MODS_PATH = ROOT / "shared" / "sourced-mods.control.meta"
 
 
 def parse_args() -> argparse.Namespace:
+    """Parse CLI arguments for manifest validation."""
     parser = argparse.ArgumentParser(
         description="Validate Ash Archive edition manifests and canonical source links."
     )
@@ -22,6 +23,7 @@ def parse_args() -> argparse.Namespace:
 
 
 def validate_repository(editions: list[str], source_path: Path = SOURCED_MODS_PATH) -> list[str]:
+    """Run manifest, sourced-mod, and source-reference validation for selected editions."""
     errors: list[str] = []
     manifest_paths = {edition: manifest_path(edition) for edition in EDITIONS}
     mods_by_edition: dict[str, list[dict]] = {}
@@ -58,6 +60,7 @@ def validate_repository(editions: list[str], source_path: Path = SOURCED_MODS_PA
 
 
 def main() -> int:
+    """CLI entry point."""
     args = parse_args()
     editions = [args.edition] if args.edition else list(EDITIONS)
     errors = validate_repository(editions)


### PR DESCRIPTION
## Summary

This keeps repository documentation aligned with the current skill/preset inventory and improves maintainability of the Python tooling surface. The change removes duplicated preset/skill entries from local policy docs and adds docstrings plus a few clarifying inline comments for exported tooling functions.

It intentionally does not change manifest data, edition scope, acceptance state, compatibility claims, roadmap gates, or release-readiness language.

## Area affected

- [x] Shared sourcing or policy
- [ ] Pilgrim / OpenMW
- [ ] Sleeper / MWSE
- [x] Tooling or schema
- [x] Documentation
- [ ] Continuous integration
- [ ] Wabbajack planning

## Evidence and uncertainty

Repository evidence:
- `ash-archive/LOCAL-AGENT-PRESETS.md` contained duplicated sections and repeated entries in preset/skill inventories; those duplicates were removed so docs match the repo state.
- Exported/public Python tooling functions now include docstrings across `ash-archive/tools/` and `ash-archive/tools/lib/` files touched in this PR.
- Inline comments were added only around non-obvious source-reference consistency logic in `tools/lib/validation.py`.

In-game/source uncertainty:
- N/A. This PR does not introduce or alter mod provenance, versions, archives, plugin facts, compatibility evidence, or playtest outcomes.

## Validation

Run from `ash-archive/` or explain each skipped command:

```bash
python tools/lint_repo.py
python tools/validate_manifests.py
python tools/check_duplicate_mods.py
python tools/compare_editions.py
python tools/generate_modlist_markdown.py --check
pytest
```

- Commands run and exact results:
  - `python tools/lint_repo.py` -> passed
  - `python tools/validate_manifests.py` -> passed for `openmw, mwse`
  - `pytest` -> passed (`137 passed`)
- Commands skipped and reasons:
  - `python tools/check_duplicate_mods.py` skipped (no manifest data changes)
  - `python tools/compare_editions.py` skipped (no edition manifest logic changes)
  - `python tools/generate_modlist_markdown.py --check` skipped (no manifest edits affecting generated modlists)
- Generated modlists refreshed with `python tools/generate_modlist_markdown.py` when needed:
  - Not needed for this PR.
- Generated diffs reviewed:
  - N/A.

## Human review gates

- [x] No unverified mod was promoted to `testing` or `accepted`.
- [x] Any `source_reference` added is provenance-only and was not treated as promotion, acceptance, or compatibility evidence.
- [x] Candidate and edition status changes are explained separately.
- [x] No final load order, installability, compatibility, or release-readiness claim was added without evidence.
- [x] OpenMW and MWSE remain sibling editions; intentional engine-specific differences were preserved.
- [x] Generated sections were not hand-edited.
- [x] Rejected-mod reasoning and unresolved research questions were retained.
- [x] Project-bible exceptions, source promotion, compatibility decisions, and release decisions received human review where required.